### PR TITLE
fix: declare data-machine as required plugin

### DIFF
--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -12,6 +12,7 @@
  * Requires at least: 6.9
  * Tested up to: 6.9
  * Requires PHP: 7.4
+ * Requires Plugins: data-machine
  *
  * @package ExtraChillRoadie
  * @since 0.1.0


### PR DESCRIPTION
## Summary

Adds `Requires Plugins: data-machine` header to `extrachill-roadie.php`.

## Why

Roadie's runtime dependency on Data Machine was previously **implicit** — only enforced via `class_exists()` guards on:
- `DataMachine\Engine\AI\Tools\BaseTool` (in `inc/tools/register.php`)
- `DataMachine\Core\Database\Agents\Agents` (in `inc/permissions.php`)

Without DM active, roadie was a silent no-op: tools wouldn't register, agent policy wouldn't sync, permission bridge wouldn't fire — and there was no surface telling the admin why.

With this header, WordPress refuses to activate roadie unless `data-machine` is also present, and the plugins screen shows the dependency relationship explicitly.

## Audit context

This came out of a Phase-0 dependency audit (thread: refactor planning). Audit verdict was **STAY-AS-DM-AGENT** — roadie's only DM imports are:
- `DataMachine\Engine\AI\Tools\BaseTool` — base for 4 chat tools registered via `datamachine_tools` filter
- `DataMachine\Core\Database\Agents\Agents` — direct repo access to sync canonical roadie agent name/status/redirect-uris
- 3 DM-namespaced filter hooks: `datamachine_tools` (×4 via BaseTool), `datamachine_can_access_agent`, `datamachine_bridge_onboarding_config`

Adding the explicit header makes the contract visible.

## Risk

Minimal. Header-only change. No behavior change for sites that already have DM active (which is the only configuration where roadie was ever functional).