### PR TITLE
fix(tools): canonical JSON Schema for roadie tools

### DIFF
--- a/inc/tools/class-manage-artist-profile.php
+++ b/inc/tools/class-manage-artist-profile.php
@@ -34,46 +34,42 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Manage artist profiles on the Extra Chill platform. Can list the current user\'s artists, get artist details, create a new artist profile, or update an existing one (name, bio, genre, city, images). If the user has only one artist, it is auto-selected.',
 			'parameters'  => array(
-				'action'           => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action to perform: "list" (list user\'s artists), "get" (get artist details), "create" (create new artist), "update" (update existing artist)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'           => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: "list" (list user\'s artists), "get" (get artist details), "create" (create new artist), "update" (update existing artist)',
+					),
+					'artist_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID. Required for "get" and "update". Omit for "list" and "create". If the user has only one artist, this is auto-resolved.',
+					),
+					'name'             => array(
+						'type'        => 'string',
+						'description' => 'Artist/band name. Required for "create", optional for "update".',
+					),
+					'bio'              => array(
+						'type'        => 'string',
+						'description' => 'Artist bio/description. HTML is allowed. Used in "create" and "update".',
+					),
+					'genre'            => array(
+						'type'        => 'string',
+						'description' => 'Music genre (e.g. "Indie Rock", "Hip Hop"). Used in "create" and "update".',
+					),
+					'local_city'       => array(
+						'type'        => 'string',
+						'description' => 'City/scene the artist is based in (e.g. "Austin, TX"). Used in "create" and "update".',
+					),
+					'profile_image_id' => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "update".',
+					),
+					'header_image_id'  => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for header image. Pass 0 to remove. Used in "update".',
+					),
 				),
-				'artist_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Artist profile ID. Required for "get" and "update". Omit for "list" and "create". If the user has only one artist, this is auto-resolved.',
-				),
-				'name'             => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Artist/band name. Required for "create", optional for "update".',
-				),
-				'bio'              => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Artist bio/description. HTML is allowed. Used in "create" and "update".',
-				),
-				'genre'            => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Music genre (e.g. "Indie Rock", "Hip Hop"). Used in "create" and "update".',
-				),
-				'local_city'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'City/scene the artist is based in (e.g. "Austin, TX"). Used in "create" and "update".',
-				),
-				'profile_image_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "update".',
-				),
-				'header_image_id'  => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for header image. Pass 0 to remove. Used in "update".',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/tools/class-manage-community.php
+++ b/inc/tools/class-manage-community.php
@@ -37,56 +37,50 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Interact with the Extra Chill community forums. Browse forums, list and read topics, create new topics, post replies, and manage notifications. All actions run on community.extrachill.com.',
 			'parameters'  => array(
-				'action'          => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: "list_forums" (browse available forums), "list_topics" (list topics in a forum or all), "get_topic" (read a topic with replies), "create_topic" (post a new topic), "create_reply" (reply to a topic), "get_notifications" (check notifications), "mark_notifications_read" (mark all as read)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'          => array(
+						'type'        => 'string',
+						'description' => 'Action: "list_forums" (browse available forums), "list_topics" (list topics in a forum or all), "get_topic" (read a topic with replies), "create_topic" (post a new topic), "create_reply" (reply to a topic), "get_notifications" (check notifications), "mark_notifications_read" (mark all as read)',
+					),
+					'forum_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Forum ID. Required for "create_topic". Optional filter for "list_topics".',
+					),
+					'topic_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Topic ID. Required for "get_topic", "create_reply".',
+					),
+					'title'           => array(
+						'type'        => 'string',
+						'description' => 'Topic title. Required for "create_topic".',
+					),
+					'content'         => array(
+						'type'        => 'string',
+						'description' => 'Post content (HTML allowed). Required for "create_topic" and "create_reply".',
+					),
+					'reply_to'        => array(
+						'type'        => 'integer',
+						'description' => 'Parent reply ID for threaded replies. Used in "create_reply".',
+					),
+					'page'            => array(
+						'type'        => 'integer',
+						'description' => 'Page number for paginated results. Default: 1.',
+					),
+					'per_page'        => array(
+						'type'        => 'integer',
+						'description' => 'Results per page (max 100). Default: 20 for topics, 30 for replies.',
+					),
+					'include_replies' => array(
+						'type'        => 'boolean',
+						'description' => 'Include replies when getting a topic. Default: true.',
+					),
+					'unread'          => array(
+						'type'        => 'boolean',
+						'description' => 'Only return unread notifications. Used in "get_notifications".',
+					),
 				),
-				'forum_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Forum ID. Required for "create_topic". Optional filter for "list_topics".',
-				),
-				'topic_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Topic ID. Required for "get_topic", "create_reply".',
-				),
-				'title'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Topic title. Required for "create_topic".',
-				),
-				'content'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Post content (HTML allowed). Required for "create_topic" and "create_reply".',
-				),
-				'reply_to'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Parent reply ID for threaded replies. Used in "create_reply".',
-				),
-				'page'            => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Page number for paginated results. Default: 1.',
-				),
-				'per_page'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Results per page (max 100). Default: 20 for topics, 30 for replies.',
-				),
-				'include_replies' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include replies when getting a topic. Default: true.',
-				),
-				'unread'          => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Only return unread notifications. Used in "get_notifications".',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/tools/class-manage-link-page.php
+++ b/inc/tools/class-manage-link-page.php
@@ -37,66 +37,60 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Manage an artist\'s link page on Extra Chill. Can get the full link page, add/remove individual links, replace all links, update social links, change visual styles (colors, fonts, button shapes), and update settings (redirects, tracking pixels, subscribe mode). The artist_id is auto-resolved if the user has only one artist.',
 			'parameters'  => array(
-				'action'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: "get" (view link page), "add_link" (add a single link), "remove_link" (remove a link by URL or ID), "save_links" (replace all link sections), "save_socials" (replace social links), "save_styles" (update CSS variables), "save_settings" (update settings like redirects, tracking, subscribe mode)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'              => array(
+						'type'        => 'string',
+						'description' => 'Action: "get" (view link page), "add_link" (add a single link), "remove_link" (remove a link by URL or ID), "save_links" (replace all link sections), "save_socials" (replace social links), "save_styles" (update CSS variables), "save_settings" (update settings like redirects, tracking, subscribe mode)',
+					),
+					'artist_id'           => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID. Auto-resolved if user has one artist.',
+					),
+					'url'                 => array(
+						'type'        => 'string',
+						'description' => 'Link URL. Used in "add_link" (required) and "remove_link" (to identify by URL).',
+					),
+					'text'                => array(
+						'type'        => 'string',
+						'description' => 'Link display text. Used in "add_link".',
+					),
+					'section'             => array(
+						'type'        => 'string',
+						'description' => 'Section title to add the link to. Used in "add_link". Defaults to the first section.',
+					),
+					'link_id'             => array(
+						'type'        => 'string',
+						'description' => 'Link ID to remove. Used in "remove_link" as alternative to URL.',
+					),
+					'links'               => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Full array of link sections for "save_links". Each section: {section_title, links: [{link_text, link_url, expires_at?}]}.',
+					),
+					'socials'             => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Array of social links for "save_socials". Each: {type, url}. Types: apple_music, bandcamp, bluesky, facebook, github, instagram, patreon, pinterest, soundcloud, spotify, substack, tiktok, twitch, twitter_x, venmo, website, youtube, custom.',
+					),
+					'css_vars'            => array(
+						'type'        => 'object',
+						'description' => 'CSS variables for "save_styles". Keys must start with "--link-page-". Examples: --link-page-button-bg-color, --link-page-text-color, --link-page-background-color, --link-page-button-radius, --link-page-title-font-family, --link-page-profile-img-shape (circle/square/rectangle).',
+					),
+					'settings'            => array(
+						'type'        => 'object',
+						'description' => 'Settings for "save_settings". Keys: link_expiration_enabled (bool), redirect_enabled (bool), redirect_target_url (string), youtube_embed_enabled (bool), meta_pixel_id, google_tag_id, google_tag_manager_id, subscribe_display_mode (icon_modal/inline_form/disabled), subscribe_description, social_icons_position (above/below), profile_image_shape (circle/square/rectangle).',
+					),
+					'background_image_id' => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for background image. Pass 0 to remove. Used in "save_settings".',
+					),
+					'profile_image_id'    => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "save_settings".',
+					),
 				),
-				'artist_id'  => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Artist profile ID. Auto-resolved if user has one artist.',
-				),
-				'url'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Link URL. Used in "add_link" (required) and "remove_link" (to identify by URL).',
-				),
-				'text'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Link display text. Used in "add_link".',
-				),
-				'section'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Section title to add the link to. Used in "add_link". Defaults to the first section.',
-				),
-				'link_id'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Link ID to remove. Used in "remove_link" as alternative to URL.',
-				),
-				'links'      => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Full array of link sections for "save_links". Each section: {section_title, links: [{link_text, link_url, expires_at?}]}.',
-				),
-				'socials'    => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of social links for "save_socials". Each: {type, url}. Types: apple_music, bandcamp, bluesky, facebook, github, instagram, patreon, pinterest, soundcloud, spotify, substack, tiktok, twitch, twitter_x, venmo, website, youtube, custom.',
-				),
-				'css_vars'   => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'CSS variables for "save_styles". Keys must start with "--link-page-". Examples: --link-page-button-bg-color, --link-page-text-color, --link-page-background-color, --link-page-button-radius, --link-page-title-font-family, --link-page-profile-img-shape (circle/square/rectangle).',
-				),
-				'settings'   => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Settings for "save_settings". Keys: link_expiration_enabled (bool), redirect_enabled (bool), redirect_target_url (string), youtube_embed_enabled (bool), meta_pixel_id, google_tag_id, google_tag_manager_id, subscribe_display_mode (icon_modal/inline_form/disabled), subscribe_description, social_icons_position (above/below), profile_image_shape (circle/square/rectangle).',
-				),
-				'background_image_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for background image. Pass 0 to remove. Used in "save_settings".',
-				),
-				'profile_image_id'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "save_settings".',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/tools/class-manage-user-profile.php
+++ b/inc/tools/class-manage-user-profile.php
@@ -39,31 +39,31 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Manage the current user\'s Extra Chill profile. Can get profile details, update bio/title/city, or replace profile links. Profile links are different from artist link pages — these are the links shown on the user\'s community profile.',
 			'parameters'  => array(
-				'action'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: "get" (view profile), "update" (update bio, title, or city), "update_links" (replace profile links)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'       => array(
+						'type'        => 'string',
+						'description' => 'Action: "get" (view profile), "update" (update bio, title, or city), "update_links" (replace profile links)',
+					),
+					'custom_title' => array(
+						'type'        => 'string',
+						'description' => 'Custom profile title (e.g. "Music Producer", "Concert Photographer"). Used in "update".',
+					),
+					'bio'          => array(
+						'type'        => 'string',
+						'description' => 'User bio/description. HTML is allowed. Used in "update".',
+					),
+					'local_city'   => array(
+						'type'        => 'string',
+						'description' => 'User\'s city (e.g. "Austin, TX"). Used in "update".',
+					),
+					'links'        => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Array of profile links for "update_links". Each: {type_key, url, custom_label?}. Valid type_key values: website, facebook, instagram, twitter, youtube, tiktok, spotify, soundcloud, bandcamp, github, other. Full replacement — all existing links are replaced.',
+					),
 				),
-				'custom_title' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Custom profile title (e.g. "Music Producer", "Concert Photographer"). Used in "update".',
-				),
-				'bio'          => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'User bio/description. HTML is allowed. Used in "update".',
-				),
-				'local_city'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'User\'s city (e.g. "Austin, TX"). Used in "update".',
-				),
-				'links'        => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of profile links for "update_links". Each: {type_key, url, custom_label?}. Valid type_key values: website, facebook, instagram, twitter, youtube, tiktok, spotify, soundcloud, bandcamp, github, other. Full replacement — all existing links are replaced.',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}


### PR DESCRIPTION
## Why

Data Machine 0.106.1 ([PR #1900](https://github.com/Extra-Chill/data-machine/pull/1900) — *Require canonical AI tool schemas*) removes the auto-normalization that previously converted legacy tool parameter shapes into canonical JSON Schema. Extension plugins must now ship canonical schemas directly.

The current extrachill-roadie tools use the legacy shape (per-property `required: true/false` flags inside `parameters`). Once DM 0.106.1 lands, these schemas will fail `RequestBuilder::normalizeToolParameters` validation and the tools will be rejected by the AI provider.

This is a **pre-flight fix** landed before the DM bump. The canonical shape is **backwards compatible** with DM 0.103.x (current production), so we can merge this now without waiting for the DM upgrade.

## Files changed

All four tool definitions under `inc/tools/`:

- `class-manage-community.php`
- `class-manage-link-page.php`
- `class-manage-user-profile.php`
- `class-manage-artist-profile.php`

## What changed

For each tool's `getToolDefinition()` `parameters` block:

1. Wrapped properties in `{ type: 'object', properties: {...}, required: [...] }`.
2. Promoted every property where `required => true` into the top-level `required[]` string array (only `action` in all four tools).
3. Removed the per-property `required` key (no longer recognized).
4. Added `items: { type: 'object' }` to every `type: 'array'` property:
   - `manage_link_page`: `links`, `socials`
   - `manage_user_profile`: `links`
   - (`manage_community` and `manage_artist_profile` have no array properties.)
5. Kept all other keys (`description`, etc.) untouched.

OpenAI strict tool schema validation rejects array schemas without `items` (see MEMORY.md note from May 2026 on `data-machine-events/upsert_event` hitting the same gotcha), so this is required for the schemas to actually pass through to the provider on DM 0.106.1+.

## Backwards compatibility

Canonical JSON Schema already works on DM 0.103.14 (current production on extrachill.com) because `RequestBuilder::normalizeToolParameters` passes already-canonical shapes through unchanged. No DM version bump is required to merge this PR; it just unblocks the future bump to 0.106.1.

## Test plan

- Verified converted schemas pass `RequestBuilder::normalizeToolParameters` passthrough on DM main.
- `php -l` clean on all four files.
- `homeboy lint --path .` reports no new findings on the edited files (9 pre-existing findings in `inc/permissions.php` and elsewhere are unrelated to this changeset).
- No changes to runtime tool-call handling — only the schema definitions exposed to the AI provider were touched.

## Constraints honored

- No push to main; PR only.
- No edits to `docs/CHANGELOG.md` (homeboy owns it).
- No version constant bumps (homeboy auto-detects from conventional commits).
- All work performed in worktree `/var/lib/datamachine/workspace/extrachill-roadie@fix-canonical-tool-schemas`, never in `/var/www/`.