### PR TITLE
fix(tools): canonical JSON Schema for chat tools (#5)

### DIFF
--- a/inc/tools/class-manage-artist-profile.php
+++ b/inc/tools/class-manage-artist-profile.php
@@ -34,46 +34,42 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Manage artist profiles on the Extra Chill platform. Can list the current user\'s artists, get artist details, create a new artist profile, or update an existing one (name, bio, genre, city, images). If the user has only one artist, it is auto-selected.',
 			'parameters'  => array(
-				'action'           => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action to perform: "list" (list user\'s artists), "get" (get artist details), "create" (create new artist), "update" (update existing artist)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'           => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: "list" (list user\'s artists), "get" (get artist details), "create" (create new artist), "update" (update existing artist)',
+					),
+					'artist_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID. Required for "get" and "update". Omit for "list" and "create". If the user has only one artist, this is auto-resolved.',
+					),
+					'name'             => array(
+						'type'        => 'string',
+						'description' => 'Artist/band name. Required for "create", optional for "update".',
+					),
+					'bio'              => array(
+						'type'        => 'string',
+						'description' => 'Artist bio/description. HTML is allowed. Used in "create" and "update".',
+					),
+					'genre'            => array(
+						'type'        => 'string',
+						'description' => 'Music genre (e.g. "Indie Rock", "Hip Hop"). Used in "create" and "update".',
+					),
+					'local_city'       => array(
+						'type'        => 'string',
+						'description' => 'City/scene the artist is based in (e.g. "Austin, TX"). Used in "create" and "update".',
+					),
+					'profile_image_id' => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "update".',
+					),
+					'header_image_id'  => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for header image. Pass 0 to remove. Used in "update".',
+					),
 				),
-				'artist_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Artist profile ID. Required for "get" and "update". Omit for "list" and "create". If the user has only one artist, this is auto-resolved.',
-				),
-				'name'             => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Artist/band name. Required for "create", optional for "update".',
-				),
-				'bio'              => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Artist bio/description. HTML is allowed. Used in "create" and "update".',
-				),
-				'genre'            => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Music genre (e.g. "Indie Rock", "Hip Hop"). Used in "create" and "update".',
-				),
-				'local_city'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'City/scene the artist is based in (e.g. "Austin, TX"). Used in "create" and "update".',
-				),
-				'profile_image_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "update".',
-				),
-				'header_image_id'  => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for header image. Pass 0 to remove. Used in "update".',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/tools/class-manage-community.php
+++ b/inc/tools/class-manage-community.php
@@ -37,56 +37,50 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Interact with the Extra Chill community forums. Browse forums, list and read topics, create new topics, post replies, and manage notifications. All actions run on community.extrachill.com.',
 			'parameters'  => array(
-				'action'          => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: "list_forums" (browse available forums), "list_topics" (list topics in a forum or all), "get_topic" (read a topic with replies), "create_topic" (post a new topic), "create_reply" (reply to a topic), "get_notifications" (check notifications), "mark_notifications_read" (mark all as read)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'          => array(
+						'type'        => 'string',
+						'description' => 'Action: "list_forums" (browse available forums), "list_topics" (list topics in a forum or all), "get_topic" (read a topic with replies), "create_topic" (post a new topic), "create_reply" (reply to a topic), "get_notifications" (check notifications), "mark_notifications_read" (mark all as read)',
+					),
+					'forum_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Forum ID. Required for "create_topic". Optional filter for "list_topics".',
+					),
+					'topic_id'        => array(
+						'type'        => 'integer',
+						'description' => 'Topic ID. Required for "get_topic", "create_reply".',
+					),
+					'title'           => array(
+						'type'        => 'string',
+						'description' => 'Topic title. Required for "create_topic".',
+					),
+					'content'         => array(
+						'type'        => 'string',
+						'description' => 'Post content (HTML allowed). Required for "create_topic" and "create_reply".',
+					),
+					'reply_to'        => array(
+						'type'        => 'integer',
+						'description' => 'Parent reply ID for threaded replies. Used in "create_reply".',
+					),
+					'page'            => array(
+						'type'        => 'integer',
+						'description' => 'Page number for paginated results. Default: 1.',
+					),
+					'per_page'        => array(
+						'type'        => 'integer',
+						'description' => 'Results per page (max 100). Default: 20 for topics, 30 for replies.',
+					),
+					'include_replies' => array(
+						'type'        => 'boolean',
+						'description' => 'Include replies when getting a topic. Default: true.',
+					),
+					'unread'          => array(
+						'type'        => 'boolean',
+						'description' => 'Only return unread notifications. Used in "get_notifications".',
+					),
 				),
-				'forum_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Forum ID. Required for "create_topic". Optional filter for "list_topics".',
-				),
-				'topic_id'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Topic ID. Required for "get_topic", "create_reply".',
-				),
-				'title'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Topic title. Required for "create_topic".',
-				),
-				'content'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Post content (HTML allowed). Required for "create_topic" and "create_reply".',
-				),
-				'reply_to'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Parent reply ID for threaded replies. Used in "create_reply".',
-				),
-				'page'            => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Page number for paginated results. Default: 1.',
-				),
-				'per_page'        => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Results per page (max 100). Default: 20 for topics, 30 for replies.',
-				),
-				'include_replies' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Include replies when getting a topic. Default: true.',
-				),
-				'unread'          => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'Only return unread notifications. Used in "get_notifications".',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/tools/class-manage-link-page.php
+++ b/inc/tools/class-manage-link-page.php
@@ -37,66 +37,60 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Manage an artist\'s link page on Extra Chill. Can get the full link page, add/remove individual links, replace all links, update social links, change visual styles (colors, fonts, button shapes), and update settings (redirects, tracking pixels, subscribe mode). The artist_id is auto-resolved if the user has only one artist.',
 			'parameters'  => array(
-				'action'     => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: "get" (view link page), "add_link" (add a single link), "remove_link" (remove a link by URL or ID), "save_links" (replace all link sections), "save_socials" (replace social links), "save_styles" (update CSS variables), "save_settings" (update settings like redirects, tracking, subscribe mode)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'              => array(
+						'type'        => 'string',
+						'description' => 'Action: "get" (view link page), "add_link" (add a single link), "remove_link" (remove a link by URL or ID), "save_links" (replace all link sections), "save_socials" (replace social links), "save_styles" (update CSS variables), "save_settings" (update settings like redirects, tracking, subscribe mode)',
+					),
+					'artist_id'           => array(
+						'type'        => 'integer',
+						'description' => 'Artist profile ID. Auto-resolved if user has one artist.',
+					),
+					'url'                 => array(
+						'type'        => 'string',
+						'description' => 'Link URL. Used in "add_link" (required) and "remove_link" (to identify by URL).',
+					),
+					'text'                => array(
+						'type'        => 'string',
+						'description' => 'Link display text. Used in "add_link".',
+					),
+					'section'             => array(
+						'type'        => 'string',
+						'description' => 'Section title to add the link to. Used in "add_link". Defaults to the first section.',
+					),
+					'link_id'             => array(
+						'type'        => 'string',
+						'description' => 'Link ID to remove. Used in "remove_link" as alternative to URL.',
+					),
+					'links'               => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Full array of link sections for "save_links". Each section: {section_title, links: [{link_text, link_url, expires_at?}]}.',
+					),
+					'socials'             => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Array of social links for "save_socials". Each: {type, url}. Types: apple_music, bandcamp, bluesky, facebook, github, instagram, patreon, pinterest, soundcloud, spotify, substack, tiktok, twitch, twitter_x, venmo, website, youtube, custom.',
+					),
+					'css_vars'            => array(
+						'type'        => 'object',
+						'description' => 'CSS variables for "save_styles". Keys must start with "--link-page-". Examples: --link-page-button-bg-color, --link-page-text-color, --link-page-background-color, --link-page-button-radius, --link-page-title-font-family, --link-page-profile-img-shape (circle/square/rectangle).',
+					),
+					'settings'            => array(
+						'type'        => 'object',
+						'description' => 'Settings for "save_settings". Keys: link_expiration_enabled (bool), redirect_enabled (bool), redirect_target_url (string), youtube_embed_enabled (bool), meta_pixel_id, google_tag_id, google_tag_manager_id, subscribe_display_mode (icon_modal/inline_form/disabled), subscribe_description, social_icons_position (above/below), profile_image_shape (circle/square/rectangle).',
+					),
+					'background_image_id' => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for background image. Pass 0 to remove. Used in "save_settings".',
+					),
+					'profile_image_id'    => array(
+						'type'        => 'integer',
+						'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "save_settings".',
+					),
 				),
-				'artist_id'  => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Artist profile ID. Auto-resolved if user has one artist.',
-				),
-				'url'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Link URL. Used in "add_link" (required) and "remove_link" (to identify by URL).',
-				),
-				'text'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Link display text. Used in "add_link".',
-				),
-				'section'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Section title to add the link to. Used in "add_link". Defaults to the first section.',
-				),
-				'link_id'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Link ID to remove. Used in "remove_link" as alternative to URL.',
-				),
-				'links'      => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Full array of link sections for "save_links". Each section: {section_title, links: [{link_text, link_url, expires_at?}]}.',
-				),
-				'socials'    => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of social links for "save_socials". Each: {type, url}. Types: apple_music, bandcamp, bluesky, facebook, github, instagram, patreon, pinterest, soundcloud, spotify, substack, tiktok, twitch, twitter_x, venmo, website, youtube, custom.',
-				),
-				'css_vars'   => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'CSS variables for "save_styles". Keys must start with "--link-page-". Examples: --link-page-button-bg-color, --link-page-text-color, --link-page-background-color, --link-page-button-radius, --link-page-title-font-family, --link-page-profile-img-shape (circle/square/rectangle).',
-				),
-				'settings'   => array(
-					'type'        => 'object',
-					'required'    => false,
-					'description' => 'Settings for "save_settings". Keys: link_expiration_enabled (bool), redirect_enabled (bool), redirect_target_url (string), youtube_embed_enabled (bool), meta_pixel_id, google_tag_id, google_tag_manager_id, subscribe_display_mode (icon_modal/inline_form/disabled), subscribe_description, social_icons_position (above/below), profile_image_shape (circle/square/rectangle).',
-				),
-				'background_image_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for background image. Pass 0 to remove. Used in "save_settings".',
-				),
-				'profile_image_id'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Attachment ID for profile image. Pass 0 to remove. Used in "save_settings".',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}

--- a/inc/tools/class-manage-user-profile.php
+++ b/inc/tools/class-manage-user-profile.php
@@ -39,31 +39,31 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Manage the current user\'s Extra Chill profile. Can get profile details, update bio/title/city, or replace profile links. Profile links are different from artist link pages — these are the links shown on the user\'s community profile.',
 			'parameters'  => array(
-				'action'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Action: "get" (view profile), "update" (update bio, title, or city), "update_links" (replace profile links)',
+				'type'       => 'object',
+				'properties' => array(
+					'action'       => array(
+						'type'        => 'string',
+						'description' => 'Action: "get" (view profile), "update" (update bio, title, or city), "update_links" (replace profile links)',
+					),
+					'custom_title' => array(
+						'type'        => 'string',
+						'description' => 'Custom profile title (e.g. "Music Producer", "Concert Photographer"). Used in "update".',
+					),
+					'bio'          => array(
+						'type'        => 'string',
+						'description' => 'User bio/description. HTML is allowed. Used in "update".',
+					),
+					'local_city'   => array(
+						'type'        => 'string',
+						'description' => 'User\'s city (e.g. "Austin, TX"). Used in "update".',
+					),
+					'links'        => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'object' ),
+						'description' => 'Array of profile links for "update_links". Each: {type_key, url, custom_label?}. Valid type_key values: website, facebook, instagram, twitter, youtube, tiktok, spotify, soundcloud, bandcamp, github, other. Full replacement — all existing links are replaced.',
+					),
 				),
-				'custom_title' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Custom profile title (e.g. "Music Producer", "Concert Photographer"). Used in "update".',
-				),
-				'bio'          => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'User bio/description. HTML is allowed. Used in "update".',
-				),
-				'local_city'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'User\'s city (e.g. "Austin, TX"). Used in "update".',
-				),
-				'links'        => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of profile links for "update_links". Each: {type_key, url, custom_label?}. Valid type_key values: website, facebook, instagram, twitter, youtube, tiktok, spotify, soundcloud, bandcamp, github, other. Full replacement — all existing links are replaced.',
-				),
+				'required'   => array( 'action' ),
 			),
 		);
 	}


### PR DESCRIPTION
## Why

[Data Machine 0.107.0](https://github.com/Extra-Chill/data-machine) removes the auto-normalization layer in `RequestBuilder::normalizeToolParameters` that previously converted legacy property-keyed parameter shapes into canonical JSON Schema on the way to providers. Extension plugins must now ship canonical schemas directly or chat tool calls fail with provider schema-validation errors.

Pre-flight fix: ships and deploys **independently of the DM upgrade**. Canonical schemas work on DM 0.103.14 (current production on extrachill.com) and DM 0.107.0+ (target). Same pattern as [Extra-Chill/data-machine-events#232](https://github.com/Extra-Chill/data-machine-events/pull/232).

## What changed

Converted all 4 chat tool definitions in `inc/tools/` from the legacy property-keyed shape to canonical JSON Schema.

### Files

- `inc/tools/class-manage-artist-profile.php`
- `inc/tools/class-manage-community.php`
- `inc/tools/class-manage-link-page.php`
- `inc/tools/class-manage-user-profile.php`

`inc/tools/class-ec-platform-tool.php` (abstract parent) and `inc/tools/register.php` (registration glue) were left untouched.

### Conversion rules applied

1. Wrap properties under `{ type: 'object', properties: {...} }`.
2. Move `required => true` properties into a top-level `required[]` array of property names; remove `required` from individual property defs.
3. Drop `required => false` entirely (it was a no-op).
4. Preserve `description` and `enum` keys verbatim.
5. **Every `type: array` property gains an `items` schema** (OpenAI strict tool-schema validation requires it).

### Required fields summary

All four tools have a single required field: `action`.

### `items` schema choices for array fields

Audit found two files with `type: array` properties. For each, I read the field name + description carefully and picked the appropriate `items` shape:

**`class-manage-link-page.php`**

- `links` → `items: { type: object }` — array of link-section structs (`{section_title, links: [{link_text, link_url, expires_at?}]}`). Nested objects, not scalars.
- `socials` → `items: { type: object }` — array of social-link structs (`{type, url}`). Nested objects, not scalars.

**`class-manage-user-profile.php`**

- `links` → `items: { type: object }` — array of profile-link structs (`{type_key, url, custom_label?}`). Nested objects, not scalars.

All three array fields carry structured records, so `items: { type: object }` is the correct minimal schema. Going deeper (declaring `properties` on the items) would over-constrain the AI tool surface — these structs already support optional fields (`expires_at`, `custom_label`) and the downstream REST endpoints validate the shape.

## Backwards compatibility

No behavior change on the current site. Canonical schemas are accepted by both DM 0.103.14 (current production) and DM 0.107.0+ (target). The legacy normalization path on 0.103.x silently passes canonical schemas through.

## Test plan

- [x] `php -l` passes on all 4 edited files.
- [x] `homeboy lint extrachill-roadie --path .` shows **zero findings** on the 4 changed files. (The 9 baseline findings in this repo are all in unrelated files: `inc/permissions.php`, etc. Pre-existing, out of scope.)
- [x] Manually inspected each diff to confirm idiomatic conversion.
- [ ] Live tool calls post-merge: `manage_artist_profile` action=list, `manage_community` action=list_forums, `manage_link_page` action=get, `manage_user_profile` action=get.

## Constraints honored

- Branched off `main`, no commits to `main`.
- No `CHANGELOG.md` edits, no version constant bumps — homeboy owns those.
- No deploy, no release.

Closes #5