### PR TITLE
Brand Roadie frontend chat

### DIFF
--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -28,6 +28,7 @@ define( 'EXTRACHILL_ROADIE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/tools/register.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/permissions.php';
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/frontend-chat.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/onboarding.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/assets.php';
 

--- a/inc/frontend-chat.php
+++ b/inc/frontend-chat.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Frontend Agent Chat branding for Roadie.
+ *
+ * @package ExtraChillRoadie
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Brand the generic frontend chat launcher for Roadie.
+ *
+ * @param array $config Frontend chat configuration.
+ * @return array
+ */
+function extrachill_roadie_frontend_chat_config( array $config ): array {
+	$agent_slug = sanitize_title( (string) ( $config['agent_slug'] ?? '' ) );
+	if ( '' !== $agent_slug && EXTRACHILL_ROADIE_AGENT_SLUG !== $agent_slug ) {
+		return $config;
+	}
+
+	$config['fab_label'] = EXTRACHILL_ROADIE_AGENT_NAME;
+
+	return $config;
+}
+add_filter( 'frontend_agent_chat_config', 'extrachill_roadie_frontend_chat_config' );

--- a/tests/frontend-chat-branding-smoke.php
+++ b/tests/frontend-chat-branding-smoke.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Smoke tests for Roadie frontend chat branding.
+ *
+ * Run with: php tests/frontend-chat-branding-smoke.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$GLOBALS['extrachill_roadie_test_filters'] = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['extrachill_roadie_test_filters'][ $hook ][] = $callback;
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	foreach ( $GLOBALS['extrachill_roadie_test_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+
+	return $value;
+}
+
+function sanitize_title( $value ): string {
+	$value = strtolower( (string) $value );
+	$value = preg_replace( '/[^a-z0-9_-]+/', '-', $value );
+	return trim( (string) $value, '-' );
+}
+
+function roadie_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/permissions.php';
+require_once dirname( __DIR__ ) . '/inc/frontend-chat.php';
+
+$roadie_config = apply_filters( 'frontend_agent_chat_config', array( 'agent_slug' => 'roadie' ) );
+roadie_smoke_assert( 'Roadie' === ( $roadie_config['fab_label'] ?? '' ), 'Roadie config should brand the frontend chat launcher.' );
+
+$default_config = apply_filters( 'frontend_agent_chat_config', array() );
+roadie_smoke_assert( 'Roadie' === ( $default_config['fab_label'] ?? '' ), 'Empty config should default to Roadie branding when Roadie owns the consumer plugin.' );
+
+$other_config = apply_filters( 'frontend_agent_chat_config', array( 'agent_slug' => 'other-agent' ) );
+roadie_smoke_assert( ! isset( $other_config['fab_label'] ), 'Other explicitly configured agents should keep their launcher branding.' );
+
+echo "Roadie frontend chat branding smoke passed (3 assertions).\n";


### PR DESCRIPTION
## Summary
- Add a Roadie-owned `frontend_agent_chat_config` hook to brand the generic launcher as `Roadie`.
- Preserve explicitly configured non-Roadie agents so the consumer hook does not override unrelated frontend chat branding.
- Add a pure PHP smoke test covering Roadie/default/other-agent config behavior.

## Testing
- `php -l inc/frontend-chat.php`
- `php -l extrachill-roadie.php`
- `php tests/frontend-chat-branding-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Roadie frontend chat branding hook, smoke test, and verification commands for Chris to review.