### PR TITLE
feat(token-bridge): migrate to frontend-agent-chat 0.8.x token surface

### DIFF
--- a/assets/css/token-bridge.css
+++ b/assets/css/token-bridge.css
@@ -1,40 +1,58 @@
 /**
  * Extra Chill Roadie — Token Bridge
  *
- * Maps Extra Chill theme tokens to Data Machine frontend chat
- * --datamachine-* custom properties. This is the EC-specific glue
- * that makes the generic DM chat widget look native on EC sites.
+ * Maps Extra Chill theme tokens to Frontend Agent Chat
+ * --frontend-agent-chat-* custom properties. This is the EC-specific
+ * glue that makes the generic FAC widget look native on EC sites.
  *
- * DM core tokens (shared across DM plugins):
- *   EC theme → --datamachine-text-primary, --datamachine-border-1, etc.
+ * Frontend Agent Chat is runtime-agnostic by design — it consumes
+ * Agents API abilities, not Data Machine internals. The token bridge
+ * lives here in Roadie (the EC platform consumer), never in FAC.
  *
- * FAB-specific tokens (frontend chat widget):
- *   EC theme → --datamachine-fab-bg, --datamachine-drawer-bg, etc.
+ * Token surface (all upstream from frontend-agent-chat 0.8.x):
+ *   FAB:       --frontend-agent-chat-fab-{bg,color,border-color,font-size,offset,badge-bg}
+ *   Drawer:    --frontend-agent-chat-drawer-{bg,width}
+ *   Surface:   --frontend-agent-chat-{accent,text-primary,text-muted,border-color,bg-muted}
+ *   Typography:--frontend-agent-chat-{font-family,header-font-family,font-size,header-font-size}
+ *   Spacing:   --frontend-agent-chat-spacing-{xs,sm,md,lg}
+ *   Surfaces:  --frontend-agent-chat-{input-bg,message-bg,warning-bg,warning-text}
  *
  * @package ExtraChillRoadie
- * @since 0.5.0
+ * @since 0.6.0
  */
 
 :root {
-	/* Data Machine core tokens ← EC theme tokens */
-	--datamachine-text-primary: var(--text-color, #333);
-	--datamachine-text-muted: var(--muted-text, #757575);
-	--datamachine-border-1: var(--border-color, #dcdcde);
-	--datamachine-bg-light: var(--card-background, #f9f9f9);
-	--datamachine-bg-lighter: var(--background-color, #f8f9fa);
-	--datamachine-blue: var(--accent, #0073aa);
-	--datamachine-color-error: var(--error-color, #d63638);
-	--datamachine-spacing-xs: var(--spacing-sm, 12px);
-	--datamachine-spacing-md: var(--spacing-md, 16px);
-	--datamachine-spacing-lg: var(--spacing-lg, 24px);
-	--datamachine-font-family: var(--font-family-body, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	/* ── FAB chrome ─────────────────────────────────────── */
+	--frontend-agent-chat-fab-bg: var(--header-background, #1a1a2e);
+	--frontend-agent-chat-fab-color: var(--header-text-color, #fff);
+	--frontend-agent-chat-fab-border-color: var(--border-color, transparent);
+	--frontend-agent-chat-fab-font-size: var(--font-size-base, 15px);
+	--frontend-agent-chat-fab-badge-bg: var(--error-color, #d63638);
 
-	/* FAB widget tokens ← EC theme tokens */
-	--datamachine-fab-bg: var(--header-background, #1a1a2e);
-	--datamachine-fab-color: var(--header-text-color, #fff);
-	--datamachine-fab-border-color: var(--border-color, transparent);
-	--datamachine-fab-font-family: var(--font-family-heading, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-	--datamachine-fab-font-size: var(--font-size-base, 15px);
-	--datamachine-drawer-bg: var(--card-background, #f1f5f9);
-	--datamachine-header-font-family: var(--font-family-heading, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	/* ── Drawer ─────────────────────────────────────────── */
+	--frontend-agent-chat-drawer-bg: var(--card-background, #f1f5f9);
+	--frontend-agent-chat-drawer-width: 420px;
+
+	/* ── Surface colors ─────────────────────────────────── */
+	--frontend-agent-chat-accent: var(--accent, #0073aa);
+	--frontend-agent-chat-text-primary: var(--text-color, #333);
+	--frontend-agent-chat-text-muted: var(--muted-text, #757575);
+	--frontend-agent-chat-border-color: var(--border-color, #dcdcde);
+	--frontend-agent-chat-bg-muted: var(--background-color, #f8f9fa);
+	--frontend-agent-chat-input-bg: var(--background-color, #f8f9fa);
+	--frontend-agent-chat-message-bg: var(--card-background, #f9f9f9);
+	--frontend-agent-chat-warning-bg: var(--error-color, #d63638);
+	--frontend-agent-chat-warning-text: #fff;
+
+	/* ── Typography ─────────────────────────────────────── */
+	--frontend-agent-chat-font-family: var(--font-family-body, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	--frontend-agent-chat-header-font-family: var(--font-family-heading, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+	--frontend-agent-chat-font-size: var(--font-size-base, 15px);
+	--frontend-agent-chat-header-font-size: 18px;
+
+	/* ── Spacing ────────────────────────────────────────── */
+	--frontend-agent-chat-spacing-xs: var(--spacing-xs, 8px);
+	--frontend-agent-chat-spacing-sm: var(--spacing-sm, 12px);
+	--frontend-agent-chat-spacing-md: var(--spacing-md, 16px);
+	--frontend-agent-chat-spacing-lg: var(--spacing-lg, 24px);
 }

--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Extra Chill Roadie
  * Plugin URI: https://extrachill.com
- * Description: Extra Chill platform chat tools for Data Machine agents. Provides artist profiles, link pages, user profiles, and community forum tools via the datamachine_tools filter.
+ * Description: Extra Chill platform integration for Frontend Agent Chat. Provides artist profiles, link pages, user profiles, and community forum tools via the datamachine_tools filter, plus the EC theme token bridge for the chat widget.
  * Version: 0.5.2
  * Author: Chris Huber
  * Author URI: https://chubes.net

--- a/inc/permissions.php
+++ b/inc/permissions.php
@@ -109,7 +109,7 @@ function extrachill_roadie_get_agent_id(): int {
 
 	$agent_id = 0;
 
-	if ( ! function_exists( 'data_machine_frontend_chat_get_config' ) ) {
+	if ( ! function_exists( 'frontend_agent_chat_get_config' ) ) {
 		return $agent_id;
 	}
 


### PR DESCRIPTION
## Summary

Migrate the Roadie token-bridge from the legacy `--datamachine-*` token namespace to the new `--frontend-agent-chat-*` namespace introduced upstream in `frontend-agent-chat` 0.8.x.

Upstream FAC was renamed from `data-machine-frontend-chat` to `frontend-agent-chat` and decoupled from Data Machine entirely — it now consumes Agents API abilities directly. As part of that work, every CSS class and CSS custom property was renamed to drop the `datamachine` vendor identifier. The token bridge in this plugin (the EC consumer) needs to follow.

## What changed

- **`assets/css/token-bridge.css`** — rewritten to map EC theme tokens to `--frontend-agent-chat-*` properties. Expanded surface to cover everything FAC 0.8.x exposes (accent, text-primary/muted, border-color, bg-muted, input-bg, message-bg, warning-bg/text, full spacing scale, header-font-size). Previous bridge only covered FAB chrome + a few core tokens.
- **`inc/permissions.php`** — `function_exists()` guard updated from `data_machine_frontend_chat_get_config` to `frontend_agent_chat_get_config`.
- **`extrachill-roadie.php`** — plugin description updated. Roadie is no longer "chat tools for Data Machine agents" — it's the EC integration for Frontend Agent Chat, providing platform tools (artist profile, link page, user profile, community) plus the theme token bridge.

## Why no `--datamachine-*` back-compat layer

Per discussion in `#extra-chill`: no back-compat. FAC has already shipped 0.8.4 upstream, the namespace is gone, the EC install will deploy the new FAC alongside this PR.

## Token mapping reference

| EC theme token | → | FAC token |
|---|---|---|
| `--header-background` | → | `--frontend-agent-chat-fab-bg` |
| `--header-text-color` | → | `--frontend-agent-chat-fab-color` |
| `--accent` | → | `--frontend-agent-chat-accent` |
| `--text-color` | → | `--frontend-agent-chat-text-primary` |
| `--muted-text` | → | `--frontend-agent-chat-text-muted` |
| `--border-color` | → | `--frontend-agent-chat-border-color` |
| `--card-background` | → | `--frontend-agent-chat-drawer-bg` / `-message-bg` |
| `--background-color` | → | `--frontend-agent-chat-bg-muted` / `-input-bg` |
| `--error-color` | → | `--frontend-agent-chat-fab-badge-bg` / `-warning-bg` |
| `--font-family-{body,heading}` | → | `--frontend-agent-chat-{font-family,header-font-family}` |
| `--font-size-base` | → | `--frontend-agent-chat-{font-size,fab-font-size}` |
| `--spacing-{xs,sm,md,lg}` | → | `--frontend-agent-chat-spacing-{xs,sm,md,lg}` |

## How to verify

After this PR merges and is deployed alongside frontend-agent-chat 0.8.4:

1. Log in as a team member (`extrachill_team=1`) on any subsite
2. Confirm the FAB renders in the bottom-right with EC header colors (not the FAC defaults `#1a1a2e` / `#fff`)
3. Open the drawer — confirm the surface uses EC card/background colors, accent matches `--accent`
4. Confirm typography inherits from the EC theme

## Constraints honored

- Conventional commit message
- No CHANGELOG.md edits (homeboy owns it)
- No version bump in source (homeboy will compute from `feat:` commit)
- No layer violation: this plugin is the EC consumer; FAC has no EC names anywhere