### PR TITLE
fix(frontend-chat): clear default 'AI' fab_icon so FAB shows 'Roadie' alone

### DIFF
--- a/inc/frontend-chat.php
+++ b/inc/frontend-chat.php
@@ -23,6 +23,10 @@ function extrachill_roadie_frontend_chat_config( array $config ): array {
 
 	$config['fab_label'] = EXTRACHILL_ROADIE_AGENT_NAME;
 
+	// Suppress the generic "AI" leading-icon label; Roadie ships with no FAB icon yet.
+	// When a Roadie brand mark is ready, set this to an SVG path string instead.
+	$config['fab_icon'] = '';
+
 	return $config;
 }
 add_filter( 'frontend_agent_chat_config', 'extrachill_roadie_frontend_chat_config' );


### PR DESCRIPTION
FAC defaults `fab_icon` to `'AI'` which renders next to `fab_label`, producing 'AI Roadie' instead of just 'Roadie' on EC sites.

Explicitly clear the icon when the active agent is Roadie. When a Roadie brand mark is ready, set this to an SVG path string instead.