### PR TITLE
feat: sandbox-backed code contribution flow

### DIFF
--- a/docs/contribute-code.md
+++ b/docs/contribute-code.md
@@ -1,52 +1,92 @@
 # Sandbox-backed contribute-code flow
 
-The `propose_code_change` chat tool dispatches a [WP Codebox](https://github.com/chubes4/wp-codebox) sandbox that makes a bounded code change against the current subsite's stack and opens a pull request on GitHub for human review.
+Team members chat with Roadie on any subsite, describe a code change, and Roadie:
 
-This document covers the platform-operator side — what to configure so the flow actually runs.
+1. Dispatches a [WP Codebox](https://github.com/chubes4/wp-codebox) Playground sandbox that implements the change against the subsite's stack.
+2. Surfaces the resulting **patch artifact** + **live preview URL** back to chat for human review.
+3. On explicit approval, applies the patch to a fresh workspace worktree on the host, commits with a conventional commit message, pushes, and opens a pull request on GitHub.
 
-## How the flow works
+The sandbox never touches GitHub, never touches production code, and never holds the GitHub token. All git operations happen on the host **after** a human approves the artifact in chat.
 
-1. A team member (admin or editor by default) opens Roadie chat on any subsite.
-2. They describe a code change in natural language.
-3. The model calls the `propose_code_change` tool.
-4. Roadie detects the active theme + subsite-specific plugins, builds a recipe (mounts + repo metadata), and invokes the `wp-codebox/run-agent-task` ability.
-5. WP Codebox boots a WordPress Playground sandbox with those mounts, plus the agent stack (Data Machine, DMC, AI providers) as read-only references.
-6. The sandboxed agent implements the change, commits with conventional-commit messages, pushes the branch, and opens a PR via DMC Code's GitHub tools.
-7. WP Codebox captures an artifact bundle on teardown and exposes a live preview URL (held for 15 minutes by default).
-8. Roadie surfaces the artifact summary, changed files, PR URL, and preview URL back to chat.
+## Two chat tools, two-step flow
 
-## Configuration
+| Tool | When called | What it does |
+|---|---|---|
+| `propose_code_change` | User describes a change | Dispatches sandbox, returns `artifact_id` + `preview_url` + `summary` + `changed_files`. **No git operations.** |
+| `apply_code_change` | After user explicitly approves the artifact | Reads artifact from disk, creates worktree per affected repo, applies patch, commits, pushes, opens PR. Returns `pr_urls`. |
 
-### 1. The GitHub token
+The structural human gate is: the LLM is told in `propose_code_change`'s description not to auto-call `apply_code_change` — it must wait for the user to approve. Capability check on both tools (`extrachill_propose_code`) is the second gate.
 
-The sandboxed agent needs a `GITHUB_TOKEN` to push and open PRs. Per the WP Codebox `secret_env` contract, **only the env var name** is passed in the ability input. The actual value lives in the WordPress PHP process environment.
+## Setup
 
-In `wp-config.php` (or a `.env` loaded by WordPress), add:
+### 1. Host prerequisites
 
-```php
-// Platform bot token used by the contribute-code sandbox.
-putenv( 'GITHUB_TOKEN=' . 'ghp_XXXXXXXXXXXXXXXX' );
-```
+- `wp-codebox` plugin installed and network-activated on the network.
+- `wp-codebox` CLI binary available on the VPS (see `wp_codebox_bin` network option).
+- DMC workspace clones present at `/var/lib/datamachine/workspace/<repo>` for every theme and plugin slug in the `extrachill_roadie_repo_map`. Create with `wp datamachine-code workspace clone <repo>`.
+- `gh` CLI installed on the VPS.
 
-Use a personal access token (classic or fine-grained) for the platform bot identity. It needs `repo` scope (or fine-grained equivalent: contents read/write + pull requests read/write) on every repo the contribute-code flow might target.
-
-If you prefer a different env var name (e.g. you already have `EXTRACHILL_BOT_GH_TOKEN` exported), set the network option:
+### 2. wp-codebox network options
 
 ```bash
-wp --allow-root --path=/var/www/extrachill.com network meta update 1 extrachill_roadie_github_token_env EXTRACHILL_BOT_GH_TOKEN
+# Path to wp-codebox CLI
+wp --allow-root --path=/var/www/extrachill.com network meta update 1 wp_codebox_bin /usr/local/bin/wp-codebox
+
+# Where artifact bundles get written
+wp --allow-root --path=/var/www/extrachill.com network meta update 1 wp_codebox_artifacts_root /var/lib/datamachine/artifacts/wp-codebox
+
+# Component paths wp-codebox auto-mounts into every sandbox (the agent stack)
+wp --allow-root --path=/var/www/extrachill.com network meta update 1 wp_codebox_component_paths \
+  '{"agents_api":"/var/lib/datamachine/workspace/agents-api","data_machine":"/var/lib/datamachine/workspace/data-machine","data_machine_code":"/var/lib/datamachine/workspace/data-machine-code","provider_plugins":["/var/lib/datamachine/workspace/ai-provider-for-openai"]}' \
+  --format=json
 ```
 
-Or filter:
+Roadie does **not** include the agent stack in its own recipe — wp-codebox handles it via these network options. Including them would double-mount.
+
+### 3. GitHub token (host-only, for apply-back)
+
+The `apply_code_change` tool shells out to `git push` and `gh pr create` on the host. Both pick up `GITHUB_TOKEN` from the PHP process environment. **The token never enters the sandbox** — sandboxes don't push.
+
+In `wp-config.php`:
 
 ```php
-add_filter( 'extrachill_roadie_github_token_env_name', fn() => 'EXTRACHILL_BOT_GH_TOKEN' );
+putenv( 'GITHUB_TOKEN=' . 'ghp_xxxxxxxxxxxx' );
 ```
 
-The tool fails with a clear error if the named env var isn't set in the parent process.
+Token needs `repo` scope (classic) or fine-grained equivalent (contents read/write + pull requests read/write) on every Extra-Chill repo the flow might target. To use a different env var name:
 
-### 2. Capabilities
+```php
+add_filter( 'extrachill_roadie_apply_github_token_env', fn() => 'EC_BOT_GH_TOKEN' );
+```
 
-By default, administrators and editors get `extrachill_propose_code`. Override the role grant:
+The tool fails with a clear error if the env var isn't set or is empty.
+
+### 4. OpenAI credentials (inheritance, bridged from options to env)
+
+The sandboxed coding agent uses OpenAI by default. The credential lives in the parent site's `connectors_ai_openai_api_key` option (WordPress 7.0 connectors API).
+
+Roadie hooks `wp_codebox_resolve_inheritance` (shipped in [chubes4/wp-codebox#89](https://github.com/chubes4/wp-codebox/pull/89), foundation for [#88](https://github.com/chubes4/wp-codebox/issues/88)). When `propose_code_change` dispatches with `inherit: { connectors: ['openai'] }`, our resolver:
+
+1. Reads the value from `connectors_ai_openai_api_key`.
+2. `putenv()`s it as `OPENAI_API_KEY` on the host PHP process.
+3. Returns metadata `{ provider: 'openai', model: 'gpt-5', secretEnv: ['OPENAI_API_KEY'] }` to wp-codebox.
+
+WP Codebox then carries the `OPENAI_API_KEY` env var name through `secret_env` into the sandbox, where `php-ai-client`'s `ProviderRegistry` resolves it via `getenv()` at provider registration time.
+
+**This is a temporary bridge.** When the wp-codebox inheritance contract grows to support filter-returned values (the remaining scope on #88), the `putenv()` bridge will be removed and the filter will return the value directly.
+
+Override the connector→metadata map for new connectors or different models:
+
+```php
+add_filter( 'extrachill_roadie_inherit_connectors', function ( array $map ) {
+    $map['openai']['model'] = 'gpt-5-mini';
+    return $map;
+} );
+```
+
+### 5. Capabilities
+
+By default, administrators and editors get `extrachill_propose_code`. Override:
 
 ```php
 add_filter( 'extrachill_roadie_propose_code_roles', function ( array $roles ) {
@@ -54,13 +94,9 @@ add_filter( 'extrachill_roadie_propose_code_roles', function ( array $roles ) {
 } );
 ```
 
-Or grant per-user via the standard `user_has_cap` filter / role editor.
+### 6. Slug → repo map
 
-### 3. Slug → repo map
-
-The recipe builder maps active components on the subsite to GitHub repos via the `extrachill_roadie_repo_map` filter. Defaults cover the Extra Chill stack (theme + commonly active plugins + agent stack references).
-
-Add a new plugin to the map:
+The recipe builder maps active components on the subsite to GitHub repos via the `extrachill_roadie_repo_map` filter. Defaults cover the Extra Chill theme + commonly active plugins. Add new entries:
 
 ```php
 add_filter( 'extrachill_roadie_repo_map', function ( array $map ) {
@@ -74,51 +110,107 @@ add_filter( 'extrachill_roadie_repo_map', function ( array $map ) {
 } );
 ```
 
-If a contributor describes a change to a plugin that isn't in the map, the recipe still ships, but that plugin won't be mounted as editable, and the response includes the unmapped slug in `unmapped_plugins` for operator visibility.
+If a contributor describes a change to a plugin that isn't in the map, the recipe still ships but that plugin won't be mounted as editable. The response includes the unmapped slug in `unmapped_plugins` for operator visibility.
 
-### 4. Network-active boilerplate exclusion
+## Architecture
 
-Platform-wide plugins (Data Machine, AI providers, the roadie plugin itself, etc.) are excluded by default from the subsite's editable surface — they mount in via the agent stack as read-only references. Override the exclusion list:
-
-```php
-add_filter( 'extrachill_roadie_excluded_plugin_slugs', function ( array $slugs ) {
-    $slugs[] = 'some-plugin-to-also-exclude';
-    return $slugs;
-} );
 ```
+┌────────────────────────────────────────────────────────────────────┐
+│  community.extrachill.com — user chats with Roadie                 │
+│    "fix the typo in reply notification text"                       │
+└──────────────────────────────┬─────────────────────────────────────┘
+                               │
+                propose_code_change(task_description)
+                               │
+┌──────────────────────────────▼─────────────────────────────────────┐
+│  Roadie (host)                                                      │
+│  1. Capability check                                                │
+│  2. Detect subsite context (active theme + plugins, minus network) │
+│  3. Build recipe:                                                   │
+│       mounts from /var/lib/datamachine/workspace/<repo>             │
+│       metadata.baselineSource = source                              │
+│  4. wp-codebox/run-agent-task with:                                 │
+│       inherit.connectors: ['openai']                                │
+│       preview_hold_seconds: 900                                     │
+└──────────────────────────────┬─────────────────────────────────────┘
+                               │
+┌──────────────────────────────▼─────────────────────────────────────┐
+│  WP Codebox sandbox (PHP-WASM Playground)                           │
+│  - Boots fresh WP                                                   │
+│  - Mounts workspace clones into in-memory VFS                       │
+│  - Activates agent stack (agents-api, DM, DMC, OpenAI provider)     │
+│  - Resolves OPENAI_API_KEY via php-ai-client connectors             │
+│  - Runs the agent loop; agent edits files in VFS                    │
+│  - Teardown: captureMountDiffs() emits patch.diff + review.json     │
+│  - Holds preview URL for 900s                                       │
+└──────────────────────────────┬─────────────────────────────────────┘
+                               │ artifact bundle
+┌──────────────────────────────▼─────────────────────────────────────┐
+│  Roadie chat                                                        │
+│    Shows: summary, preview URL, changed files, artifact_id          │
+│    Says: "Approve to commit & open PR"                              │
+└──────────────────────────────┬─────────────────────────────────────┘
+                               │  user types "approve"
+              apply_code_change(artifact_id)
+                               │
+┌──────────────────────────────▼─────────────────────────────────────┐
+│  Roadie (host) — apply-back                                         │
+│  For each readwrite mount with changes:                             │
+│    1. wp datamachine-code workspace worktree add <repo> <branch>    │
+│    2. Translate sandbox paths → repo-root paths in patch            │
+│    3. git apply                                                     │
+│    4. git commit -m "fix(<slug>): <summary>"                        │
+│    5. git push origin <branch>                                      │
+│    6. gh pr create (uses GITHUB_TOKEN from host env)                │
+│  Returns pr_urls back to chat                                       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Sandbox boundary: nothing crosses except (1) mounted host files into VFS at boot, (2) artifact bundle out on teardown. No git, no GitHub token, no network egress from the sandbox process.
 
 ## Manual smoke test
 
-To exercise the flow end-to-end against the live wp-codebox install:
+```bash
+# 1. Verify env is set up
+wp --allow-root --path=/var/www/extrachill.com network meta get 1 wp_codebox_bin
+wp --allow-root --path=/var/www/extrachill.com network meta get 1 wp_codebox_component_paths
+echo "GITHUB_TOKEN=${GITHUB_TOKEN:+set}"
 
-1. **Prerequisites:**
-   - `wp-codebox` plugin active on the network.
-   - `GITHUB_TOKEN` (or your configured env var) exported in the WordPress PHP process.
-   - Logged-in user with `extrachill_propose_code` capability.
+# 2. Trigger propose tool
+wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com eval '
+$tool = new ECRoadie_ProposeCodeChange();
+$result = $tool->handle_tool_call( array(
+    "task_description" => "Add a one-line comment with the word ROADIE_SMOKE_TEST near the top of the main plugin file of extrachill-community."
+) );
+echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
 
-2. **Trigger from CLI** (mimics what the chat layer does):
+# Note the artifact_id from the output. Visit the preview_url to confirm
+# the change applied inside the sandbox.
 
-   ```bash
-   wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com \
-       eval '
-   $tool = new ECRoadie_ProposeCodeChange();
-   $result = $tool->handle_tool_call( array(
-       "task_description" => "Add a comment with the word ROADIE_SMOKE_TEST to the top of the main plugin file of extrachill-community."
-   ) );
-   echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
-   ```
+# 3. Approve and apply
+wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com eval '
+$tool = new ECRoadie_ApplyCodeChange();
+$result = $tool->handle_tool_call( array( "artifact_id" => "ARTIFACT_ID_HERE" ) );
+echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
 
-3. **Verify:**
-   - Response `success` is `true`.
-   - `data.pr_url` points at a new PR in `Extra-Chill/extrachill-community`.
-   - `data.preview_url` opens for ~15 minutes after dispatch.
-   - The artifact bundle exists under the configured artifacts root.
+# Expect: data.pr_urls[0] = https://github.com/Extra-Chill/extrachill-community/pull/N
 
-4. **Clean up:** close the smoke-test PR without merging.
+# 4. Close the smoke-test PR on GitHub without merging.
+```
 
 ## Operational notes
 
 - **Preview URL TTL:** controlled by `preview_hold_seconds` (default 900). Override via `extrachill_roadie_preview_hold_seconds` filter. Max 3600.
-- **No nested DMC coordination:** the sandbox is self-contained. DMC + DMC Code run inside the Playground, not on the parent site.
-- **PR review still happens on GitHub:** the flow opens the PR; merge stays with the human reviewer. There is no in-WordPress approval step.
-- **Long-running sandboxes:** wp-codebox runs sandboxes synchronously. For long tasks, expect the chat round-trip to take however long the sandbox takes.
+- **Worktree convention:** apply-back creates worktrees as `<repo>@roadie-<slug>-<short-artifact-id>`. These are tracked in the DMC workspace registry and can be cleaned up via `wp datamachine-code workspace worktree mark-cleanup-eligible <handle>` after PR merge.
+- **Commit identity:** all commits authored by `Extra Chill Bot <bot@extrachill.com>` using the host `GITHUB_TOKEN`. Override via `extrachill_roadie_apply_commit_name` / `extrachill_roadie_apply_commit_email` filters.
+- **No release / no deploy:** apply-back opens a PR; merge and release stay manual on GitHub. There is no path from chat to production deploy.
+
+## Upstream dependencies & open work
+
+| Issue | Status | What it gives us |
+|---|---|---|
+| [chubes4/wp-codebox#88](https://github.com/chubes4/wp-codebox/issues/88) | Partial (closed via #89) | Declarative inheritance contract for connectors/settings. The `inherit` block + `wp_codebox_resolve_inheritance` filter are live. |
+| [chubes4/wp-codebox#89](https://github.com/chubes4/wp-codebox/pull/89) | Merged | Transport foundation for #88. Provider/model/secret_env-names crossover via the filter. |
+| Remaining #88 scope | Open | Agent identity inheritance (custom SOUL/MEMORY for the sandbox agent) + filter-returned secret values (eliminating the putenv() bridge). |
+
+When the remaining #88 scope lands, the `inherit-resolver.php` bridge becomes obsolete: the filter will return values directly instead of `putenv()`ing them, and we can also pass an `inherit.agents` block to give the sandboxed agent a tailored persona.

--- a/docs/contribute-code.md
+++ b/docs/contribute-code.md
@@ -1,0 +1,124 @@
+# Sandbox-backed contribute-code flow
+
+The `propose_code_change` chat tool dispatches a [WP Codebox](https://github.com/chubes4/wp-codebox) sandbox that makes a bounded code change against the current subsite's stack and opens a pull request on GitHub for human review.
+
+This document covers the platform-operator side — what to configure so the flow actually runs.
+
+## How the flow works
+
+1. A team member (admin or editor by default) opens Roadie chat on any subsite.
+2. They describe a code change in natural language.
+3. The model calls the `propose_code_change` tool.
+4. Roadie detects the active theme + subsite-specific plugins, builds a recipe (mounts + repo metadata), and invokes the `wp-codebox/run-agent-task` ability.
+5. WP Codebox boots a WordPress Playground sandbox with those mounts, plus the agent stack (Data Machine, DMC, AI providers) as read-only references.
+6. The sandboxed agent implements the change, commits with conventional-commit messages, pushes the branch, and opens a PR via DMC Code's GitHub tools.
+7. WP Codebox captures an artifact bundle on teardown and exposes a live preview URL (held for 15 minutes by default).
+8. Roadie surfaces the artifact summary, changed files, PR URL, and preview URL back to chat.
+
+## Configuration
+
+### 1. The GitHub token
+
+The sandboxed agent needs a `GITHUB_TOKEN` to push and open PRs. Per the WP Codebox `secret_env` contract, **only the env var name** is passed in the ability input. The actual value lives in the WordPress PHP process environment.
+
+In `wp-config.php` (or a `.env` loaded by WordPress), add:
+
+```php
+// Platform bot token used by the contribute-code sandbox.
+putenv( 'GITHUB_TOKEN=' . 'ghp_XXXXXXXXXXXXXXXX' );
+```
+
+Use a personal access token (classic or fine-grained) for the platform bot identity. It needs `repo` scope (or fine-grained equivalent: contents read/write + pull requests read/write) on every repo the contribute-code flow might target.
+
+If you prefer a different env var name (e.g. you already have `EXTRACHILL_BOT_GH_TOKEN` exported), set the network option:
+
+```bash
+wp --allow-root --path=/var/www/extrachill.com network meta update 1 extrachill_roadie_github_token_env EXTRACHILL_BOT_GH_TOKEN
+```
+
+Or filter:
+
+```php
+add_filter( 'extrachill_roadie_github_token_env_name', fn() => 'EXTRACHILL_BOT_GH_TOKEN' );
+```
+
+The tool fails with a clear error if the named env var isn't set in the parent process.
+
+### 2. Capabilities
+
+By default, administrators and editors get `extrachill_propose_code`. Override the role grant:
+
+```php
+add_filter( 'extrachill_roadie_propose_code_roles', function ( array $roles ) {
+    return array( 'administrator', 'editor', 'author' );
+} );
+```
+
+Or grant per-user via the standard `user_has_cap` filter / role editor.
+
+### 3. Slug → repo map
+
+The recipe builder maps active components on the subsite to GitHub repos via the `extrachill_roadie_repo_map` filter. Defaults cover the Extra Chill stack (theme + commonly active plugins + agent stack references).
+
+Add a new plugin to the map:
+
+```php
+add_filter( 'extrachill_roadie_repo_map', function ( array $map ) {
+    $map['new-extra-chill-plugin'] = array(
+        'repo'                        => 'Extra-Chill/new-extra-chill-plugin',
+        'default_branch'              => 'main',
+        'repo_root_relative_to_mount' => '',
+        'kind'                        => 'plugin',
+    );
+    return $map;
+} );
+```
+
+If a contributor describes a change to a plugin that isn't in the map, the recipe still ships, but that plugin won't be mounted as editable, and the response includes the unmapped slug in `unmapped_plugins` for operator visibility.
+
+### 4. Network-active boilerplate exclusion
+
+Platform-wide plugins (Data Machine, AI providers, the roadie plugin itself, etc.) are excluded by default from the subsite's editable surface — they mount in via the agent stack as read-only references. Override the exclusion list:
+
+```php
+add_filter( 'extrachill_roadie_excluded_plugin_slugs', function ( array $slugs ) {
+    $slugs[] = 'some-plugin-to-also-exclude';
+    return $slugs;
+} );
+```
+
+## Manual smoke test
+
+To exercise the flow end-to-end against the live wp-codebox install:
+
+1. **Prerequisites:**
+   - `wp-codebox` plugin active on the network.
+   - `GITHUB_TOKEN` (or your configured env var) exported in the WordPress PHP process.
+   - Logged-in user with `extrachill_propose_code` capability.
+
+2. **Trigger from CLI** (mimics what the chat layer does):
+
+   ```bash
+   wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com \
+       eval '
+   $tool = new ECRoadie_ProposeCodeChange();
+   $result = $tool->handle_tool_call( array(
+       "task_description" => "Add a comment with the word ROADIE_SMOKE_TEST to the top of the main plugin file of extrachill-community."
+   ) );
+   echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
+   ```
+
+3. **Verify:**
+   - Response `success` is `true`.
+   - `data.pr_url` points at a new PR in `Extra-Chill/extrachill-community`.
+   - `data.preview_url` opens for ~15 minutes after dispatch.
+   - The artifact bundle exists under the configured artifacts root.
+
+4. **Clean up:** close the smoke-test PR without merging.
+
+## Operational notes
+
+- **Preview URL TTL:** controlled by `preview_hold_seconds` (default 900). Override via `extrachill_roadie_preview_hold_seconds` filter. Max 3600.
+- **No nested DMC coordination:** the sandbox is self-contained. DMC + DMC Code run inside the Playground, not on the parent site.
+- **PR review still happens on GitHub:** the flow opens the PR; merge stays with the human reviewer. There is no in-WordPress approval step.
+- **Long-running sandboxes:** wp-codebox runs sandboxes synchronously. For long tasks, expect the chat round-trip to take however long the sandbox takes.

--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -31,6 +31,10 @@ require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/permissions.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/frontend-chat.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/onboarding.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/assets.php';
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/subsite-context.php';
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/repo-map.php';
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/recipe-builder.php';
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/capabilities.php';
 
 /**
  * Bootstrap Roadie policy hooks.

--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -35,6 +35,7 @@ require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/subsite-context
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/repo-map.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/recipe-builder.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/capabilities.php';
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/contribute-code/inherit-resolver.php';
 
 /**
  * Bootstrap Roadie policy hooks.

--- a/inc/contribute-code/capabilities.php
+++ b/inc/contribute-code/capabilities.php
@@ -1,11 +1,15 @@
 <?php
 /**
- * Capability mapping for the contribute-code chat tool.
+ * Capability mapping for the contribute-code chat tools.
  *
  * Adds `extrachill_propose_code` and grants it to administrators and editors
  * by default. Override the role grant via the
  * `extrachill_roadie_propose_code_roles` filter; override per-user via the
  * `user_has_cap` filter as usual.
+ *
+ * Both `propose_code_change` and `apply_code_change` gate on this cap. There
+ * is no separate "approve" cap because chat approval already happens through
+ * the same conversation surface — if you can propose, you can approve.
  *
  * @package ExtraChillRoadie\ContributeCode
  * @since 0.7.0
@@ -81,63 +85,37 @@ function extrachill_roadie_grant_propose_code_cap( array $allcaps, array $caps, 
 add_filter( 'user_has_cap', 'extrachill_roadie_grant_propose_code_cap', 10, 4 );
 
 /**
- * Resolve the network option name that holds the platform bot GitHub token name.
+ * Env var name holding the GitHub token used by the apply-back tool.
  *
- * The option stores ONLY the env var NAME (e.g. "GITHUB_TOKEN"). The actual
- * token value lives in the WordPress PHP process environment — typically in
- * `wp-config.php` (`putenv()`) or `.env` — because that is what the WP
- * Codebox `secret_env` contract requires.
+ * Apply-back shells out to `gh pr create` (and underlying `git push`) on the
+ * host. Both pick up `GITHUB_TOKEN` from the process environment. The token
+ * never crosses into the sandbox — sandboxes don't push.
+ *
+ * Override the env var name via the `extrachill_roadie_apply_github_token_env`
+ * filter if your host exports the token under a different name.
  *
  * @since 0.7.0
  * @return string
  */
-function extrachill_roadie_github_token_option_name(): string {
-	return 'extrachill_roadie_github_token_env';
-}
-
-/**
- * Resolve the configured GitHub token env var name.
- *
- * Defaults to `GITHUB_TOKEN` when the network option is unset. The actual
- * value is read from `getenv()` by WP Codebox at sandbox-dispatch time.
- *
- * @since 0.7.0
- * @return string Env var name (never empty).
- */
-function extrachill_roadie_github_token_env_name(): string {
-	$option = extrachill_roadie_github_token_option_name();
-	$name   = '';
-	if ( function_exists( 'get_site_option' ) ) {
-		$name = (string) get_site_option( $option, '' );
-	}
-	if ( '' === $name && function_exists( 'get_option' ) ) {
-		$name = (string) get_option( $option, '' );
-	}
-	if ( '' === $name ) {
-		$name = 'GITHUB_TOKEN';
-	}
-
+function extrachill_roadie_apply_github_token_env_name(): string {
 	/**
-	 * Filter the env var name that holds the platform bot GitHub token.
+	 * Filter the env var name holding the GitHub token for apply-back.
 	 *
 	 * @since 0.7.0
 	 *
-	 * @param string $name Env var name.
+	 * @param string $default Default env var name.
 	 */
-	return (string) apply_filters( 'extrachill_roadie_github_token_env_name', $name );
+	return (string) apply_filters( 'extrachill_roadie_apply_github_token_env', 'GITHUB_TOKEN' );
 }
 
 /**
- * Check whether the env var named by extrachill_roadie_github_token_env_name()
- * has a non-empty value in the parent process environment.
- *
- * Used by the chat tool to fail fast with a clear error message.
+ * Check whether the apply-back GitHub token env var is present and non-empty.
  *
  * @since 0.7.0
  * @return bool
  */
-function extrachill_roadie_github_token_is_present(): bool {
-	$name = extrachill_roadie_github_token_env_name();
+function extrachill_roadie_apply_github_token_present(): bool {
+	$name = extrachill_roadie_apply_github_token_env_name();
 	if ( '' === $name ) {
 		return false;
 	}

--- a/inc/contribute-code/capabilities.php
+++ b/inc/contribute-code/capabilities.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Capability mapping for the contribute-code chat tool.
+ *
+ * Adds `extrachill_propose_code` and grants it to administrators and editors
+ * by default. Override the role grant via the
+ * `extrachill_roadie_propose_code_roles` filter; override per-user via the
+ * `user_has_cap` filter as usual.
+ *
+ * @package ExtraChillRoadie\ContributeCode
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const EXTRACHILL_ROADIE_PROPOSE_CODE_CAP = 'extrachill_propose_code';
+
+/**
+ * Roles that get `extrachill_propose_code` by default.
+ *
+ * @since 0.7.0
+ * @return string[]
+ */
+function extrachill_roadie_propose_code_default_roles(): array {
+	$defaults = array( 'administrator', 'editor' );
+
+	/**
+	 * Filter the roles that automatically get the contribute-code capability.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param string[] $defaults Default role slugs.
+	 */
+	$roles = apply_filters( 'extrachill_roadie_propose_code_roles', $defaults );
+
+	if ( ! is_array( $roles ) ) {
+		return $defaults;
+	}
+
+	return array_values( array_unique( array_map( 'strval', $roles ) ) );
+}
+
+/**
+ * Grant the contribute-code capability via the `user_has_cap` filter.
+ *
+ * Using `user_has_cap` (instead of writing to role objects on activation)
+ * keeps the grant role-driven and filterable, and avoids touching DB state
+ * on plugin upgrades.
+ *
+ * @since 0.7.0
+ *
+ * @param array<string,bool> $allcaps All capabilities the user currently has.
+ * @param array<int,string>  $caps    Required primitive capabilities for the requested cap.
+ * @param array<int,mixed>   $args    [0] requested cap, [1] user id, [2] object id.
+ * @param WP_User|null       $user    User object.
+ * @return array<string,bool>
+ */
+function extrachill_roadie_grant_propose_code_cap( array $allcaps, array $caps, array $args, $user ): array {
+	unset( $caps, $args );
+
+	if ( ! $user || empty( $user->roles ) ) {
+		return $allcaps;
+	}
+
+	if ( ! empty( $allcaps[ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] ) ) {
+		return $allcaps;
+	}
+
+	$granted_roles = extrachill_roadie_propose_code_default_roles();
+	foreach ( (array) $user->roles as $role ) {
+		if ( in_array( $role, $granted_roles, true ) ) {
+			$allcaps[ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] = true;
+			return $allcaps;
+		}
+	}
+
+	return $allcaps;
+}
+add_filter( 'user_has_cap', 'extrachill_roadie_grant_propose_code_cap', 10, 4 );
+
+/**
+ * Resolve the network option name that holds the platform bot GitHub token name.
+ *
+ * The option stores ONLY the env var NAME (e.g. "GITHUB_TOKEN"). The actual
+ * token value lives in the WordPress PHP process environment — typically in
+ * `wp-config.php` (`putenv()`) or `.env` — because that is what the WP
+ * Codebox `secret_env` contract requires.
+ *
+ * @since 0.7.0
+ * @return string
+ */
+function extrachill_roadie_github_token_option_name(): string {
+	return 'extrachill_roadie_github_token_env';
+}
+
+/**
+ * Resolve the configured GitHub token env var name.
+ *
+ * Defaults to `GITHUB_TOKEN` when the network option is unset. The actual
+ * value is read from `getenv()` by WP Codebox at sandbox-dispatch time.
+ *
+ * @since 0.7.0
+ * @return string Env var name (never empty).
+ */
+function extrachill_roadie_github_token_env_name(): string {
+	$option = extrachill_roadie_github_token_option_name();
+	$name   = '';
+	if ( function_exists( 'get_site_option' ) ) {
+		$name = (string) get_site_option( $option, '' );
+	}
+	if ( '' === $name && function_exists( 'get_option' ) ) {
+		$name = (string) get_option( $option, '' );
+	}
+	if ( '' === $name ) {
+		$name = 'GITHUB_TOKEN';
+	}
+
+	/**
+	 * Filter the env var name that holds the platform bot GitHub token.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param string $name Env var name.
+	 */
+	return (string) apply_filters( 'extrachill_roadie_github_token_env_name', $name );
+}
+
+/**
+ * Check whether the env var named by extrachill_roadie_github_token_env_name()
+ * has a non-empty value in the parent process environment.
+ *
+ * Used by the chat tool to fail fast with a clear error message.
+ *
+ * @since 0.7.0
+ * @return bool
+ */
+function extrachill_roadie_github_token_is_present(): bool {
+	$name = extrachill_roadie_github_token_env_name();
+	if ( '' === $name ) {
+		return false;
+	}
+	$value = getenv( $name );
+	return is_string( $value ) && '' !== trim( $value );
+}

--- a/inc/contribute-code/inherit-resolver.php
+++ b/inc/contribute-code/inherit-resolver.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * WP Codebox inheritance resolver.
+ *
+ * Hooks `wp_codebox_resolve_inheritance` (shipped in chubes4/wp-codebox#89,
+ * the foundation for chubes4/wp-codebox#88) to declaratively wire parent-site
+ * connector state into sandbox dispatches.
+ *
+ * Today's contract (per wp-codebox v0.x):
+ *
+ * - Roadie's `propose_code_change` tool passes `inherit.connectors = ['openai']`.
+ * - WP Codebox calls this filter with the request + ability input.
+ * - We return a resolution structure with provider/model/secretEnv NAMES per
+ *   connector. WP Codebox merges those secretEnv names into the sandbox's
+ *   secret_env passthrough and uses provider/model as defaults.
+ * - The actual credential VALUE must already be in the host PHP process env
+ *   at dispatch time. WP Codebox does not accept secret values through this
+ *   filter (chubes4/wp-codebox#89 description: "secret values and setting
+ *   values are not serialized into recipe JSON, artifact metadata, logs, or
+ *   patches by this transport slice").
+ *
+ * For OpenAI: the production key lives in the `connectors_ai_openai_api_key`
+ * option (WordPress connectors API). We bridge it into the PHP process env
+ * as `OPENAI_API_KEY` right here so wp-codebox's secret_env mechanism can
+ * carry the NAME into the sandbox, where php-ai-client's ProviderRegistry
+ * reads it via getenv().
+ *
+ * When the upstream contract grows (filter-returned values, agent identity
+ * inheritance, pre-plugins_loaded hydration), this bridge becomes obsolete
+ * and the filter return shrinks to pure metadata.
+ *
+ * @package ExtraChillRoadie\ContributeCode
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Default connector → metadata map.
+ *
+ * Each entry describes:
+ *   - provider:     wp-ai-client provider id
+ *   - model:        default model the sandbox agent should use
+ *   - secret_env:   array of env var names the sandbox needs
+ *   - option_key:   parent option holding the credential value
+ *   - env_var:      env var name to putenv() (must appear in secret_env)
+ *
+ * Override via the `extrachill_roadie_inherit_connectors` filter.
+ *
+ * @since 0.7.0
+ * @return array<string, array<string,mixed>>
+ */
+function extrachill_roadie_default_connector_map(): array {
+	$defaults = array(
+		'openai' => array(
+			'provider'   => 'openai',
+			'model'      => 'gpt-5',
+			'secret_env' => array( 'OPENAI_API_KEY' ),
+			'option_key' => 'connectors_ai_openai_api_key',
+			'env_var'    => 'OPENAI_API_KEY',
+		),
+	);
+
+	/**
+	 * Filter the connector→metadata map used to resolve inheritance requests.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param array $defaults Default map.
+	 */
+	$filtered = apply_filters( 'extrachill_roadie_inherit_connectors', $defaults );
+
+	if ( ! is_array( $filtered ) ) {
+		return $defaults;
+	}
+
+	return $filtered;
+}
+
+/**
+ * Read a connector credential value from where it actually lives on the
+ * parent site.
+ *
+ * Today: site option store. As stores change (e.g. encrypted secrets,
+ * per-user OAuth) this is the only function that needs updating.
+ *
+ * @since 0.7.0
+ *
+ * @param string $option_key Option name holding the credential.
+ * @return string Credential value, or empty string if absent.
+ */
+function extrachill_roadie_read_connector_value( string $option_key ): string {
+	if ( '' === $option_key || ! function_exists( 'get_option' ) ) {
+		return '';
+	}
+	$value = get_option( $option_key, '' );
+	return is_string( $value ) ? trim( $value ) : '';
+}
+
+/**
+ * Filter callback for `wp_codebox_resolve_inheritance`.
+ *
+ * Receives the pre-populated $resolution (one entry per requested name with
+ * status='unresolved') and walks the connector entries, filling in metadata
+ * for any name we know about. Side-effect: for each resolved connector with
+ * an `option_key`, also calls putenv() to expose the credential value to
+ * the host PHP process so wp-codebox's secret_env passthrough finds it.
+ *
+ * @since 0.7.0
+ *
+ * @param array $resolution Pre-populated resolution structure.
+ * @param array $request    Requested inheritance (connectors[], settings[]).
+ * @param array $input      Full ability input (unused here).
+ * @return array Mutated resolution structure.
+ */
+function extrachill_roadie_resolve_inheritance( $resolution, $request, $input ): array {
+	unset( $input );
+
+	if ( ! is_array( $resolution ) ) {
+		$resolution = array( 'connectors' => array(), 'settings' => array() );
+	}
+
+	$connector_map = extrachill_roadie_default_connector_map();
+	$connectors    = is_array( $resolution['connectors'] ?? null ) ? $resolution['connectors'] : array();
+
+	foreach ( $connectors as $idx => $entry ) {
+		if ( ! is_array( $entry ) ) {
+			continue;
+		}
+		$name = (string) ( $entry['name'] ?? '' );
+		if ( '' === $name || ! isset( $connector_map[ $name ] ) ) {
+			continue;
+		}
+
+		$meta  = $connector_map[ $name ];
+		$value = '';
+		if ( ! empty( $meta['option_key'] ) ) {
+			$value = extrachill_roadie_read_connector_value( (string) $meta['option_key'] );
+		}
+
+		if ( '' === $value ) {
+			$connectors[ $idx ] = array(
+				'name'   => $name,
+				'status' => 'missing-credential',
+			);
+			continue;
+		}
+
+		// Bridge: export the value into the host PHP process env under the
+		// configured env var name. WP Codebox's secret_env will inherit it.
+		if ( ! empty( $meta['env_var'] ) ) {
+			putenv( $meta['env_var'] . '=' . $value );
+		}
+
+		$connectors[ $idx ] = array(
+			'name'      => $name,
+			'status'    => 'resolved',
+			'provider'  => (string) ( $meta['provider'] ?? '' ),
+			'model'     => (string) ( $meta['model'] ?? '' ),
+			'secretEnv' => array_values( (array) ( $meta['secret_env'] ?? array() ) ),
+		);
+	}
+
+	$resolution['connectors'] = $connectors;
+	return $resolution;
+}
+add_filter( 'wp_codebox_resolve_inheritance', 'extrachill_roadie_resolve_inheritance', 10, 3 );

--- a/inc/contribute-code/recipe-builder.php
+++ b/inc/contribute-code/recipe-builder.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Recipe builder for the sandbox-backed contribute-code flow.
+ *
+ * Translates a detected subsite context (active theme + subsite-specific
+ * plugins) plus the slug→repo map into the `mounts` array accepted by
+ * `wp-codebox/run-agent-task`.
+ *
+ * Per chubes4/wp-codebox#82 the recipe builder lives in the consumer (us),
+ * not in wp-codebox. Each mount declares source/target/mode and carries
+ * `metadata` for downstream tools that need to push back to the correct
+ * GitHub repo.
+ *
+ * @package ExtraChillRoadie\ContributeCode
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Default in-sandbox WordPress content root.
+ *
+ * WP Codebox mounts host directories under `/wordpress/wp-content/...` in
+ * the Playground filesystem.
+ */
+const EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT = '/wordpress/wp-content';
+
+/**
+ * Build a recipe (the `mounts` array) for `wp-codebox/run-agent-task`.
+ *
+ * Input:
+ *   - $context  — output of extrachill_roadie_detect_subsite_context()
+ *   - $repo_map — output of extrachill_roadie_default_repo_map() (or override)
+ *   - $args     — optional overrides:
+ *       * 'wp_content_target' (string) sandbox WP content root
+ *       * 'include_agent_stack' (bool)  default true
+ *       * 'agent_stack_plugin_paths' (array<slug,path>) host paths for the
+ *         agent stack — pulled from /var/www/extrachill.com/wp-content/plugins/
+ *         when omitted
+ *
+ * Output:
+ *   array(
+ *     'mounts'                  => array<int, array{source,target,mode,metadata}>,
+ *     'editable_targets'        => array<string,string>, // slug => sandbox target
+ *     'agent_stack_targets'     => array<string,string>, // slug => sandbox target
+ *     'unmapped_active_plugins' => string[],             // slugs without repo entries
+ *   )
+ *
+ * @since 0.7.0
+ *
+ * @param array $context  Subsite context.
+ * @param array $repo_map Slug→repo map.
+ * @param array $args     Optional overrides.
+ * @return array<string,mixed>
+ */
+function extrachill_roadie_build_recipe( array $context, array $repo_map, array $args = array() ): array {
+	$wp_content_target   = (string) ( $args['wp_content_target'] ?? EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT );
+	$include_agent_stack = (bool) ( $args['include_agent_stack'] ?? true );
+	$agent_stack_paths   = (array) ( $args['agent_stack_plugin_paths'] ?? array() );
+
+	$mounts              = array();
+	$editable_targets    = array();
+	$agent_stack_targets = array();
+	$unmapped            = array();
+
+	// 1. Theme mount (readwrite if it has a repo entry, otherwise skip).
+	$theme_slug = (string) ( $context['theme']['slug'] ?? '' );
+	$theme_path = (string) ( $context['theme']['path'] ?? '' );
+	if ( '' !== $theme_slug && '' !== $theme_path ) {
+		$entry = $repo_map[ $theme_slug ] ?? null;
+		if ( $entry && ( $entry['kind'] ?? '' ) === 'theme' ) {
+			$target          = $wp_content_target . '/themes/' . $theme_slug;
+			$mounts[]        = array(
+				'source'   => $theme_path,
+				'target'   => $target,
+				'mode'     => 'readwrite',
+				'metadata' => array(
+					'kind'                          => 'theme',
+					'slug'                          => $theme_slug,
+					'repo'                          => (string) ( $entry['repo'] ?? '' ),
+					'default_branch'                => (string) ( $entry['default_branch'] ?? 'main' ),
+					'repo_root_relative_to_mount'   => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
+				),
+			);
+			$editable_targets[ $theme_slug ] = $target;
+		} else {
+			$unmapped[] = $theme_slug;
+		}
+	}
+
+	// 2. Subsite-specific plugin mounts (readwrite when mapped).
+	foreach ( (array) ( $context['plugins'] ?? array() ) as $plugin ) {
+		$slug = (string) ( $plugin['slug'] ?? '' );
+		$path = (string) ( $plugin['path'] ?? '' );
+		if ( '' === $slug || '' === $path ) {
+			continue;
+		}
+
+		$entry = $repo_map[ $slug ] ?? null;
+		if ( ! $entry ) {
+			$unmapped[] = $slug;
+			continue;
+		}
+
+		$kind = (string) ( $entry['kind'] ?? 'plugin' );
+		if ( 'agent-stack-plugin' === $kind ) {
+			// Active on the subsite AND classified as agent stack — treat as
+			// the agent stack branch below to keep it read-only.
+			continue;
+		}
+
+		$target = $wp_content_target . '/plugins/' . $slug;
+		$mounts[] = array(
+			'source'   => $path,
+			'target'   => $target,
+			'mode'     => 'readwrite',
+			'metadata' => array(
+				'kind'                          => $kind,
+				'slug'                          => $slug,
+				'repo'                          => (string) ( $entry['repo'] ?? '' ),
+				'default_branch'                => (string) ( $entry['default_branch'] ?? 'main' ),
+				'repo_root_relative_to_mount'   => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
+			),
+		);
+		$editable_targets[ $slug ] = $target;
+	}
+
+	// 3. Agent stack — read-only references. Sandboxed agent needs these to
+	// grep DM core, DMC, AI providers, agents-api when implementing changes.
+	if ( $include_agent_stack ) {
+		$plugin_dir = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : ABSPATH . 'wp-content/plugins';
+		foreach ( extrachill_roadie_agent_stack_slugs() as $slug ) {
+			$entry = $repo_map[ $slug ] ?? null;
+			if ( ! $entry ) {
+				continue;
+			}
+
+			$host_path = $agent_stack_paths[ $slug ] ?? ( $plugin_dir . '/' . $slug );
+			$target    = $wp_content_target . '/plugins/' . $slug;
+
+			$mounts[] = array(
+				'source'   => $host_path,
+				'target'   => $target,
+				'mode'     => 'readonly',
+				'metadata' => array(
+					'kind'                          => 'agent-stack-plugin',
+					'slug'                          => $slug,
+					'repo'                          => (string) ( $entry['repo'] ?? '' ),
+					'default_branch'                => (string) ( $entry['default_branch'] ?? 'main' ),
+					'repo_root_relative_to_mount'   => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
+				),
+			);
+			$agent_stack_targets[ $slug ] = $target;
+		}
+	}
+
+	$recipe = array(
+		'mounts'                  => $mounts,
+		'editable_targets'        => $editable_targets,
+		'agent_stack_targets'     => $agent_stack_targets,
+		'unmapped_active_plugins' => array_values( array_unique( $unmapped ) ),
+	);
+
+	/**
+	 * Filter the built recipe.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param array $recipe   Recipe array.
+	 * @param array $context  Source subsite context.
+	 * @param array $repo_map Repo map used to build it.
+	 * @param array $args     Builder args.
+	 */
+	return (array) apply_filters( 'extrachill_roadie_recipe', $recipe, $context, $repo_map, $args );
+}

--- a/inc/contribute-code/recipe-builder.php
+++ b/inc/contribute-code/recipe-builder.php
@@ -2,14 +2,26 @@
 /**
  * Recipe builder for the sandbox-backed contribute-code flow.
  *
- * Translates a detected subsite context (active theme + subsite-specific
- * plugins) plus the slug→repo map into the `mounts` array accepted by
+ * Translates a detected subsite context into the `mounts` array accepted by
  * `wp-codebox/run-agent-task`.
  *
- * Per chubes4/wp-codebox#82 the recipe builder lives in the consumer (us),
- * not in wp-codebox. Each mount declares source/target/mode and carries
- * `metadata` for downstream tools that need to push back to the correct
- * GitHub repo.
+ * Key design choices:
+ *
+ * - Mount sources point at `/var/lib/datamachine/workspace/<repo>` (the DMC
+ *   primary clone), NOT at `/var/www/.../wp-content/plugins/<slug>`. The
+ *   production install is read-only reference; all sandbox-edited code is
+ *   sourced from workspace clones so the apply-back path has a real git
+ *   tree to commit against.
+ *
+ * - `metadata.baselineSource` is set on every readwrite mount so
+ *   wp-codebox's `captureMountDiffs()` emits a real `patch.diff` artifact.
+ *
+ * - The agent stack (agents-api, data-machine, data-machine-code, AI
+ *   providers) is NOT included here. WP Codebox already auto-mounts it via
+ *   the `wp_codebox_component_paths` network option / `extraPlugins` recipe
+ *   branch. Including them here would double-mount.
+ *
+ * Per chubes4/wp-codebox#82 the recipe builder lives in the consumer (us).
  *
  * @package ExtraChillRoadie\ContributeCode
  * @since 0.7.0
@@ -28,6 +40,47 @@ if ( ! defined( 'ABSPATH' ) ) {
 const EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT = '/wordpress/wp-content';
 
 /**
+ * Default DMC workspace root on disk.
+ *
+ * Override via the `extrachill_roadie_workspace_root` filter.
+ *
+ * @since 0.7.0
+ * @return string
+ */
+function extrachill_roadie_workspace_root(): string {
+	$default = '/var/lib/datamachine/workspace';
+
+	/**
+	 * Filter the DMC workspace root used for mount sources.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param string $default Default root path.
+	 */
+	return (string) apply_filters( 'extrachill_roadie_workspace_root', $default );
+}
+
+/**
+ * Resolve the on-disk workspace clone path for a repo slug.
+ *
+ * Convention: DMC clones each repo to `<workspace_root>/<repo>`. We use the
+ * primary clone (no `@<branch>` suffix) as the mount source. Apply-back
+ * tooling creates per-task worktrees from the artifact patch separately.
+ *
+ * @since 0.7.0
+ *
+ * @param string $slug Component slug.
+ * @return string Absolute path; not guaranteed to exist.
+ */
+function extrachill_roadie_workspace_clone_path( string $slug ): string {
+	$slug = trim( $slug );
+	if ( '' === $slug ) {
+		return '';
+	}
+	return extrachill_roadie_workspace_root() . '/' . $slug;
+}
+
+/**
  * Build a recipe (the `mounts` array) for `wp-codebox/run-agent-task`.
  *
  * Input:
@@ -35,17 +88,17 @@ const EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT = '/wordpress/wp-content';
  *   - $repo_map — output of extrachill_roadie_default_repo_map() (or override)
  *   - $args     — optional overrides:
  *       * 'wp_content_target' (string) sandbox WP content root
- *       * 'include_agent_stack' (bool)  default true
- *       * 'agent_stack_plugin_paths' (array<slug,path>) host paths for the
- *         agent stack — pulled from /var/www/extrachill.com/wp-content/plugins/
- *         when omitted
+ *       * 'workspace_root'    (string) override workspace root for this call
+ *       * 'require_clone'     (bool)   if true (default), skip mounts whose
+ *                                      workspace clone doesn't exist on disk
+ *                                      and track them in `missing_clones`
  *
  * Output:
  *   array(
  *     'mounts'                  => array<int, array{source,target,mode,metadata}>,
- *     'editable_targets'        => array<string,string>, // slug => sandbox target
- *     'agent_stack_targets'     => array<string,string>, // slug => sandbox target
- *     'unmapped_active_plugins' => string[],             // slugs without repo entries
+ *     'editable_targets'        => array<string,string>,  // slug => sandbox target
+ *     'unmapped_active_plugins' => string[],              // slugs without repo entries
+ *     'missing_clones'          => string[],              // slugs whose clone is absent
  *   )
  *
  * @since 0.7.0
@@ -56,45 +109,60 @@ const EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT = '/wordpress/wp-content';
  * @return array<string,mixed>
  */
 function extrachill_roadie_build_recipe( array $context, array $repo_map, array $args = array() ): array {
-	$wp_content_target   = (string) ( $args['wp_content_target'] ?? EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT );
-	$include_agent_stack = (bool) ( $args['include_agent_stack'] ?? true );
-	$agent_stack_paths   = (array) ( $args['agent_stack_plugin_paths'] ?? array() );
+	$wp_content_target = (string) ( $args['wp_content_target'] ?? EXTRACHILL_ROADIE_SANDBOX_WP_CONTENT );
+	$workspace_root    = (string) ( $args['workspace_root'] ?? extrachill_roadie_workspace_root() );
+	$require_clone     = (bool) ( $args['require_clone'] ?? true );
 
-	$mounts              = array();
-	$editable_targets    = array();
-	$agent_stack_targets = array();
-	$unmapped            = array();
+	$mounts           = array();
+	$editable_targets = array();
+	$unmapped         = array();
+	$missing_clones   = array();
 
-	// 1. Theme mount (readwrite if it has a repo entry, otherwise skip).
+	$build_mount = static function ( string $kind, string $slug, array $entry, string $sandbox_target ) use ( $workspace_root, $require_clone, &$missing_clones ): ?array {
+		$source = $workspace_root . '/' . $slug;
+		if ( $require_clone && ! is_dir( $source ) ) {
+			$missing_clones[] = $slug;
+			return null;
+		}
+
+		return array(
+			'source'   => $source,
+			'target'   => $sandbox_target,
+			'mode'     => 'readwrite',
+			'metadata' => array(
+				'kind'                        => $kind,
+				'slug'                        => $slug,
+				'repo'                        => (string) ( $entry['repo'] ?? '' ),
+				'default_branch'              => (string) ( $entry['default_branch'] ?? 'main' ),
+				'repo_root_relative_to_mount' => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
+				// captureMountDiffs() in wp-codebox only emits a patch when
+				// metadata.baselineSource is set on a readwrite mount.
+				'baselineSource'              => $source,
+				'editable'                    => true,
+			),
+		);
+	};
+
+	// 1. Theme mount (readwrite if mapped + clone exists).
 	$theme_slug = (string) ( $context['theme']['slug'] ?? '' );
-	$theme_path = (string) ( $context['theme']['path'] ?? '' );
-	if ( '' !== $theme_slug && '' !== $theme_path ) {
+	if ( '' !== $theme_slug ) {
 		$entry = $repo_map[ $theme_slug ] ?? null;
 		if ( $entry && ( $entry['kind'] ?? '' ) === 'theme' ) {
-			$target          = $wp_content_target . '/themes/' . $theme_slug;
-			$mounts[]        = array(
-				'source'   => $theme_path,
-				'target'   => $target,
-				'mode'     => 'readwrite',
-				'metadata' => array(
-					'kind'                          => 'theme',
-					'slug'                          => $theme_slug,
-					'repo'                          => (string) ( $entry['repo'] ?? '' ),
-					'default_branch'                => (string) ( $entry['default_branch'] ?? 'main' ),
-					'repo_root_relative_to_mount'   => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
-				),
-			);
-			$editable_targets[ $theme_slug ] = $target;
+			$target = $wp_content_target . '/themes/' . $theme_slug;
+			$mount  = $build_mount( 'theme', $theme_slug, $entry, $target );
+			if ( $mount ) {
+				$mounts[]                       = $mount;
+				$editable_targets[ $theme_slug ] = $target;
+			}
 		} else {
 			$unmapped[] = $theme_slug;
 		}
 	}
 
-	// 2. Subsite-specific plugin mounts (readwrite when mapped).
+	// 2. Subsite-specific plugin mounts (readwrite when mapped + clone exists).
 	foreach ( (array) ( $context['plugins'] ?? array() ) as $plugin ) {
 		$slug = (string) ( $plugin['slug'] ?? '' );
-		$path = (string) ( $plugin['path'] ?? '' );
-		if ( '' === $slug || '' === $path ) {
+		if ( '' === $slug ) {
 			continue;
 		}
 
@@ -105,62 +173,25 @@ function extrachill_roadie_build_recipe( array $context, array $repo_map, array 
 		}
 
 		$kind = (string) ( $entry['kind'] ?? 'plugin' );
+		// Agent-stack plugins are auto-mounted by wp-codebox via component
+		// paths — never include them in our recipe.
 		if ( 'agent-stack-plugin' === $kind ) {
-			// Active on the subsite AND classified as agent stack — treat as
-			// the agent stack branch below to keep it read-only.
 			continue;
 		}
 
 		$target = $wp_content_target . '/plugins/' . $slug;
-		$mounts[] = array(
-			'source'   => $path,
-			'target'   => $target,
-			'mode'     => 'readwrite',
-			'metadata' => array(
-				'kind'                          => $kind,
-				'slug'                          => $slug,
-				'repo'                          => (string) ( $entry['repo'] ?? '' ),
-				'default_branch'                => (string) ( $entry['default_branch'] ?? 'main' ),
-				'repo_root_relative_to_mount'   => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
-			),
-		);
-		$editable_targets[ $slug ] = $target;
-	}
-
-	// 3. Agent stack — read-only references. Sandboxed agent needs these to
-	// grep DM core, DMC, AI providers, agents-api when implementing changes.
-	if ( $include_agent_stack ) {
-		$plugin_dir = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : ABSPATH . 'wp-content/plugins';
-		foreach ( extrachill_roadie_agent_stack_slugs() as $slug ) {
-			$entry = $repo_map[ $slug ] ?? null;
-			if ( ! $entry ) {
-				continue;
-			}
-
-			$host_path = $agent_stack_paths[ $slug ] ?? ( $plugin_dir . '/' . $slug );
-			$target    = $wp_content_target . '/plugins/' . $slug;
-
-			$mounts[] = array(
-				'source'   => $host_path,
-				'target'   => $target,
-				'mode'     => 'readonly',
-				'metadata' => array(
-					'kind'                          => 'agent-stack-plugin',
-					'slug'                          => $slug,
-					'repo'                          => (string) ( $entry['repo'] ?? '' ),
-					'default_branch'                => (string) ( $entry['default_branch'] ?? 'main' ),
-					'repo_root_relative_to_mount'   => (string) ( $entry['repo_root_relative_to_mount'] ?? '' ),
-				),
-			);
-			$agent_stack_targets[ $slug ] = $target;
+		$mount  = $build_mount( $kind, $slug, $entry, $target );
+		if ( $mount ) {
+			$mounts[]                  = $mount;
+			$editable_targets[ $slug ] = $target;
 		}
 	}
 
 	$recipe = array(
 		'mounts'                  => $mounts,
 		'editable_targets'        => $editable_targets,
-		'agent_stack_targets'     => $agent_stack_targets,
 		'unmapped_active_plugins' => array_values( array_unique( $unmapped ) ),
+		'missing_clones'          => array_values( array_unique( $missing_clones ) ),
 	);
 
 	/**

--- a/inc/contribute-code/repo-map.php
+++ b/inc/contribute-code/repo-map.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Slug → GitHub repo map for the sandbox contribute-code flow.
+ *
+ * The recipe builder uses this map to attach `metadata.repo` and
+ * `metadata.default_branch` to each mount so the sandboxed agent can push
+ * to the correct repository when it opens its PR.
+ *
+ * This is consumer-owned (Extra Chill) per the deployment-neutral scope of
+ * chubes4/wp-codebox#82. Override entries with the
+ * `extrachill_roadie_repo_map` filter.
+ *
+ * @package ExtraChillRoadie\ContributeCode
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Default slug-to-repo mapping for the Extra Chill stack.
+ *
+ * Keys are component slugs as they appear on disk under wp-content/. Values
+ * describe the GitHub repo + repo-root-relative offset (always empty string
+ * for our repos because the plugin/theme repo IS the plugin/theme root).
+ *
+ * Slug categories are tracked via `kind`:
+ *   - `theme`              — wp-content/themes/<slug>/
+ *   - `plugin`             — wp-content/plugins/<slug>/
+ *   - `agent-stack-plugin` — read-only references the sandboxed agent needs
+ *
+ * @since 0.7.0
+ * @return array<string, array<string, string>>
+ */
+function extrachill_roadie_default_repo_map(): array {
+	$defaults = array(
+		// Themes.
+		'extrachill' => array(
+			'repo'                          => 'Extra-Chill/extrachill',
+			'default_branch'                => 'main',
+			'repo_root_relative_to_mount'   => '',
+			'kind'                          => 'theme',
+		),
+
+		// Extra Chill plugins commonly active on individual subsites.
+		'extrachill-artist-platform'  => array(
+			'repo'                        => 'Extra-Chill/extrachill-artist-platform',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-community'        => array(
+			'repo'                        => 'Extra-Chill/extrachill-community',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-events'           => array(
+			'repo'                        => 'Extra-Chill/extrachill-events',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-shop'             => array(
+			'repo'                        => 'Extra-Chill/extrachill-shop',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-blog'             => array(
+			'repo'                        => 'Extra-Chill/extrachill-blog',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-contact'          => array(
+			'repo'                        => 'Extra-Chill/extrachill-contact',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-content-blocks'   => array(
+			'repo'                        => 'Extra-Chill/extrachill-content-blocks',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-docs'             => array(
+			'repo'                        => 'Extra-Chill/extrachill-docs',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+		'extrachill-ai-adventure'     => array(
+			'repo'                        => 'Extra-Chill/extrachill-ai-adventure',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		),
+
+		// Read-only agent stack (mounted as references so the sandboxed agent
+		// can grep them, but never as editable surfaces).
+		'agents-api' => array(
+			'repo'                        => 'Automattic/agents-api',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'agent-stack-plugin',
+		),
+		'data-machine' => array(
+			'repo'                        => 'Extra-Chill/data-machine',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'agent-stack-plugin',
+		),
+		'data-machine-code' => array(
+			'repo'                        => 'Extra-Chill/data-machine-code',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'agent-stack-plugin',
+		),
+		'ai-provider-for-openai' => array(
+			'repo'                        => 'WordPress/ai-provider-for-openai',
+			'default_branch'              => 'trunk',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'agent-stack-plugin',
+		),
+		'ai-provider-for-anthropic' => array(
+			'repo'                        => 'WordPress/ai-provider-for-anthropic',
+			'default_branch'              => 'trunk',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'agent-stack-plugin',
+		),
+	);
+
+	/**
+	 * Filter the slug-to-repo map.
+	 *
+	 * Use this to add new plugins/themes, override default branches, or
+	 * shift kind classifications without modifying plugin code.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param array $defaults Default slug-to-repo map.
+	 */
+	$filtered = apply_filters( 'extrachill_roadie_repo_map', $defaults );
+
+	if ( ! is_array( $filtered ) ) {
+		return $defaults;
+	}
+
+	return $filtered;
+}
+
+/**
+ * Get the canonical list of agent-stack plugin slugs (read-only mounts).
+ *
+ * Pulled from the repo map by filtering on `kind === 'agent-stack-plugin'`.
+ *
+ * @since 0.7.0
+ * @return string[]
+ */
+function extrachill_roadie_agent_stack_slugs(): array {
+	$slugs = array();
+	foreach ( extrachill_roadie_default_repo_map() as $slug => $entry ) {
+		if ( ( $entry['kind'] ?? '' ) === 'agent-stack-plugin' ) {
+			$slugs[] = (string) $slug;
+		}
+	}
+	return $slugs;
+}

--- a/inc/contribute-code/subsite-context.php
+++ b/inc/contribute-code/subsite-context.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Subsite context detection for the sandbox-backed contribute-code flow.
+ *
+ * Pure function that, given the current blog, returns a normalized snapshot
+ * of which theme + plugins are uniquely meaningful to this subsite. The
+ * recipe builder consumes this to decide which directories to mount into a
+ * WP Codebox sandbox.
+ *
+ * Network-active boilerplate plugins (the platform-wide stack) are filtered
+ * out by default — those mount in via the agent stack section of the recipe
+ * as read-only references, not as the subsite's editable surface.
+ *
+ * @package ExtraChillRoadie\ContributeCode
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Default list of plugin slugs to treat as platform-wide boilerplate and
+ * exclude from the subsite-specific active-plugins list.
+ *
+ * These plugins are network-activated and not what a contributor would
+ * typically be editing when chatting with roadie about "this site." They
+ * mount into the sandbox separately as the agent stack.
+ *
+ * @since 0.7.0
+ * @return string[]
+ */
+function extrachill_roadie_default_excluded_plugin_slugs(): array {
+	$defaults = array(
+		// Platform-wide network plugins.
+		'breeze',
+		'imagify',
+		'extrachill-multisite',
+		'extrachill-search',
+		'extrachill-users',
+		'extrachill-admin-tools',
+		'extrachill-api',
+		'extrachill-newsletter',
+		'extrachill-seo',
+		'extrachill-analytics',
+		'extrachill-cli',
+		'chubes-gallery-lightbox',
+		'redis-cache',
+		'easy-wp-smtp',
+		'two-factor',
+		'plugin-check',
+		'html-to-blocks-converter',
+		'gutenberg',
+		// The roadie plugin itself.
+		'extrachill-roadie',
+		// Data Machine + AI substrate.
+		'data-machine',
+		'data-machine-business',
+		'data-machine-chat-bridge',
+		'data-machine-code',
+		'data-machine-editor',
+		'data-machine-events',
+		'data-machine-skills',
+		'data-machine-socials',
+		'ai-provider-for-openai',
+		'ai-provider-for-anthropic',
+		'agents-api',
+		'wp-native',
+		'frontend-agent-chat',
+	);
+
+	/**
+	 * Filter the list of plugin slugs excluded from subsite-context detection.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param string[] $defaults Default exclusion list.
+	 */
+	$filtered = apply_filters( 'extrachill_roadie_excluded_plugin_slugs', $defaults );
+
+	if ( ! is_array( $filtered ) ) {
+		return $defaults;
+	}
+
+	return array_values( array_unique( array_map( 'strval', $filtered ) ) );
+}
+
+/**
+ * Extract the plugin slug (top-level directory) from a plugin file path.
+ *
+ * WordPress identifies plugins by `slug/main-file.php` strings. For
+ * single-file plugins the slug is the filename without `.php`.
+ *
+ * @since 0.7.0
+ *
+ * @param string $plugin_file Plugin file as returned by `get_option('active_plugins')`.
+ * @return string Slug, never empty unless input was empty.
+ */
+function extrachill_roadie_plugin_file_to_slug( string $plugin_file ): string {
+	$plugin_file = trim( $plugin_file );
+
+	if ( '' === $plugin_file ) {
+		return '';
+	}
+
+	if ( false !== strpos( $plugin_file, '/' ) ) {
+		$parts = explode( '/', $plugin_file );
+		return (string) $parts[0];
+	}
+
+	// Single-file plugin: strip .php extension.
+	return preg_replace( '/\.php$/', '', $plugin_file );
+}
+
+/**
+ * Detect the current subsite's contribution context.
+ *
+ * Pure-ish: reads from WordPress globals/options but performs no writes
+ * and no network calls. Safe to call from a chat tool handler.
+ *
+ * Returned shape:
+ *   array(
+ *     'blog_id'        => int,
+ *     'site_url'       => string,
+ *     'theme'          => array(
+ *         'slug'       => string,  // stylesheet slug, e.g. 'extrachill'
+ *         'parent_slug'=> string,  // empty when not a child theme
+ *         'path'       => string,  // absolute path on host
+ *         'name'       => string,  // human-readable theme name
+ *     ),
+ *     'plugins'        => array(   // subsite-specific, excluded list applied
+ *         array(
+ *             'slug'   => string,
+ *             'file'   => string,  // 'slug/main.php'
+ *             'path'   => string,  // absolute path to plugin directory on host
+ *             'name'   => string,
+ *         ),
+ *         ...
+ *     ),
+ *     'excluded_slugs' => string[],
+ *   )
+ *
+ * @since 0.7.0
+ *
+ * @param int|null $blog_id Optional blog id; defaults to current.
+ * @return array<string,mixed>
+ */
+function extrachill_roadie_detect_subsite_context( ?int $blog_id = null ): array {
+	$blog_id = $blog_id ?: (int) get_current_blog_id();
+
+	$switched = false;
+	if ( function_exists( 'switch_to_blog' ) && $blog_id !== (int) get_current_blog_id() ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
+	$theme         = wp_get_theme();
+	$stylesheet    = $theme->get_stylesheet();
+	$theme_path    = (string) $theme->get_stylesheet_directory();
+	$parent_slug   = '';
+	$parent        = $theme->parent();
+	if ( $parent ) {
+		$parent_slug = (string) $parent->get_stylesheet();
+	}
+
+	$excluded     = extrachill_roadie_default_excluded_plugin_slugs();
+	$excluded_map = array_flip( $excluded );
+
+	$active_plugins = array();
+
+	$site_actives = (array) get_option( 'active_plugins', array() );
+
+	// Subsite-specific actives only — network-active plugins are intentionally
+	// excluded because they are platform-wide boilerplate that ships in the
+	// agent stack, not the subsite's editable surface.
+	foreach ( $site_actives as $plugin_file ) {
+		$slug = extrachill_roadie_plugin_file_to_slug( (string) $plugin_file );
+		if ( '' === $slug ) {
+			continue;
+		}
+		if ( isset( $excluded_map[ $slug ] ) ) {
+			continue;
+		}
+
+		$plugin_dir = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : ABSPATH . 'wp-content/plugins';
+		$path       = $plugin_dir . '/' . $slug;
+		$data       = array(
+			'slug' => $slug,
+			'file' => (string) $plugin_file,
+			'path' => $path,
+			'name' => $slug,
+		);
+
+		if ( function_exists( 'get_plugin_data' ) ) {
+			$full = $plugin_dir . '/' . $plugin_file;
+			if ( file_exists( $full ) ) {
+				$meta = get_plugin_data( $full, false, false );
+				if ( ! empty( $meta['Name'] ) ) {
+					$data['name'] = (string) $meta['Name'];
+				}
+			}
+		}
+
+		$active_plugins[] = $data;
+	}
+
+	$site_url = function_exists( 'home_url' ) ? (string) home_url() : '';
+
+	if ( $switched && function_exists( 'restore_current_blog' ) ) {
+		restore_current_blog();
+	}
+
+	$context = array(
+		'blog_id'        => $blog_id,
+		'site_url'       => $site_url,
+		'theme'          => array(
+			'slug'        => (string) $stylesheet,
+			'parent_slug' => $parent_slug,
+			'path'        => $theme_path,
+			'name'        => (string) $theme->get( 'Name' ),
+		),
+		'plugins'        => $active_plugins,
+		'excluded_slugs' => $excluded,
+	);
+
+	/**
+	 * Filter the detected subsite context before it is returned.
+	 *
+	 * Useful for tests or for surgical adjustments on environments where the
+	 * default exclusion list doesn't quite line up.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param array $context  Detected context.
+	 * @param int   $blog_id  Blog id the context was detected for.
+	 */
+	return (array) apply_filters( 'extrachill_roadie_subsite_context', $context, $blog_id );
+}

--- a/inc/tools/class-apply-code-change.php
+++ b/inc/tools/class-apply-code-change.php
@@ -1,0 +1,555 @@
+<?php
+/**
+ * Apply Code Change Tool
+ *
+ * Chat tool that takes a previously-generated artifact_id from
+ * propose_code_change, reads the artifact bundle from disk, and on the host:
+ *
+ *   1. For each readwrite mount with changes:
+ *      a. Resolves the workspace clone path from mount.metadata.repo /
+ *         mount.metadata.baselineSource.
+ *      b. Creates a per-task worktree via DMC's
+ *         `datamachine-code workspace worktree add` CLI on a fresh branch.
+ *      c. Applies the patch (scoped to that mount's changed files).
+ *      d. Stages, commits with a conventional commit message.
+ *      e. Pushes the branch to origin.
+ *      f. Opens a PR via `gh pr create` against the mount's repo.
+ *
+ *   2. Returns one PR URL per repo (could be multiple if the sandbox touched
+ *      multiple components).
+ *
+ * The sandbox never runs git. All git operations live here, on the host.
+ * GITHUB_TOKEN is read from the host PHP process env.
+ *
+ * @package ExtraChillRoadie\Tools
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class ECRoadie_ApplyCodeChange extends BaseTool {
+
+	protected string $tool_slug = 'apply_code_change';
+
+	public function __construct() {
+		$this->registerTool(
+			$this->tool_slug,
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'access_level' => 'authenticated' )
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Apply a previously-generated sandbox artifact: create a worktree for each affected repo, apply the patch, commit with a conventional commit message, push the branch, and open a pull request. Only call this AFTER the user has explicitly approved the proposed change (do not auto-apply). Requires artifact_id from a prior propose_code_change call.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'artifact_id' ),
+				'properties' => array(
+					'artifact_id'         => array(
+						'type'        => 'string',
+						'description' => 'Artifact bundle id returned by propose_code_change.',
+					),
+					'commit_message_hint' => array(
+						'type'        => 'string',
+						'description' => 'Optional one-line conventional-commit hint (e.g. "fix(community): typo in reply notification"). When omitted, derived from the artifact review summary.',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array $parameters
+	 * @param array $tool_def
+	 * @return array<string,mixed>
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		unset( $tool_def );
+
+		if ( ! current_user_can( EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ) ) {
+			return $this->buildErrorResponse(
+				'You do not have permission to apply code changes. Ask an administrator to grant the "extrachill_propose_code" capability.',
+				$this->tool_slug
+			);
+		}
+
+		$artifact_id = trim( (string) ( $parameters['artifact_id'] ?? '' ) );
+		if ( '' === $artifact_id ) {
+			return $this->buildErrorResponse( 'artifact_id is required.', $this->tool_slug );
+		}
+
+		if ( ! extrachill_roadie_apply_github_token_present() ) {
+			$env = extrachill_roadie_apply_github_token_env_name();
+			return $this->buildErrorResponse(
+				sprintf( 'GitHub token is not configured. The env var "%s" must be set in the WordPress PHP process for apply-back to push and open PRs. Set it via putenv() in wp-config.php (or a .env loader).', $env ),
+				$this->tool_slug
+			);
+		}
+
+		// 1. Resolve the artifact bundle from disk.
+		$bundle = $this->load_artifact_bundle( $artifact_id );
+		if ( is_wp_error( $bundle ) ) {
+			return $this->buildErrorResponse( $bundle->get_error_message(), $this->tool_slug );
+		}
+
+		// 2. Group changed files by mount index → repo metadata.
+		$grouped = $this->group_changes_by_mount( $bundle );
+		if ( empty( $grouped ) ) {
+			return $this->buildErrorResponse(
+				'Artifact contains no readwrite-mount changes to apply.',
+				$this->tool_slug
+			);
+		}
+
+		// 3. For each affected mount, create worktree + apply + commit + push + PR.
+		$commit_hint = trim( (string) ( $parameters['commit_message_hint'] ?? '' ) );
+		$results     = array();
+		$any_failure = false;
+
+		foreach ( $grouped as $entry ) {
+			$result = $this->apply_to_mount( $entry, $artifact_id, $commit_hint, $bundle );
+			$results[] = $result;
+			if ( empty( $result['success'] ) ) {
+				$any_failure = true;
+			}
+		}
+
+		return array(
+			'success'   => ! $any_failure,
+			'tool_name' => $this->tool_slug,
+			'data'      => array(
+				'artifact_id' => $artifact_id,
+				'mounts'      => $results,
+				'pr_urls'     => array_values( array_filter( array_map( static fn( $r ) => (string) ( $r['pr_url'] ?? '' ), $results ) ) ),
+			),
+		);
+	}
+
+	/**
+	 * Load and validate an artifact bundle from disk.
+	 *
+	 * Walks the configured artifacts root (network option or filter) looking
+	 * for a manifest.json whose id matches $artifact_id.
+	 *
+	 * @param string $artifact_id
+	 * @return array<string,mixed>|WP_Error
+	 */
+	protected function load_artifact_bundle( string $artifact_id ) {
+		$root = $this->resolve_artifacts_root();
+		if ( '' === $root || ! is_dir( $root ) ) {
+			return new WP_Error( 'roadie_artifacts_root_missing', 'WP Codebox artifacts root is not configured or does not exist.' );
+		}
+
+		// wp-codebox writes each runtime's artifacts under a runtime-id
+		// subdirectory of $root. Scan one level deep for matching manifest.
+		$candidates = glob( rtrim( $root, '/' ) . '/*/manifest.json' ) ?: array();
+		foreach ( $candidates as $manifest_path ) {
+			$json = @file_get_contents( $manifest_path );
+			if ( false === $json ) {
+				continue;
+			}
+			$decoded = json_decode( $json, true );
+			if ( ! is_array( $decoded ) ) {
+				continue;
+			}
+			if ( (string) ( $decoded['id'] ?? '' ) === $artifact_id ) {
+				$decoded['_bundle_dir']      = dirname( $manifest_path );
+				$decoded['_patch_path']      = dirname( $manifest_path ) . '/files/patch.diff';
+				$decoded['_changed_files']  = dirname( $manifest_path ) . '/files/changed-files.json';
+				return $decoded;
+			}
+		}
+
+		return new WP_Error( 'roadie_artifact_not_found', sprintf( 'No artifact bundle found for id "%s" under %s.', $artifact_id, $root ) );
+	}
+
+	/**
+	 * Resolve the configured wp-codebox artifacts root.
+	 *
+	 * @return string
+	 */
+	protected function resolve_artifacts_root(): string {
+		$root = '';
+		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+			$root = (string) get_site_option( 'wp_codebox_artifacts_root', '' );
+		}
+		if ( '' === $root && function_exists( 'get_option' ) ) {
+			$root = (string) get_option( 'wp_codebox_artifacts_root', '' );
+		}
+		/**
+		 * Filter the artifacts root used by apply_code_change.
+		 *
+		 * @since 0.7.0
+		 *
+		 * @param string $root Configured root.
+		 */
+		return (string) apply_filters( 'extrachill_roadie_artifacts_root', $root );
+	}
+
+	/**
+	 * Group changed_files by mount index, attaching mount metadata.
+	 *
+	 * Returns an array of:
+	 *   array(
+	 *     'mount_index'   => int,
+	 *     'mount'         => array{source,target,mode,metadata},
+	 *     'changed_paths' => string[],  // sandbox-relative paths
+	 *   )
+	 *
+	 * @param array $bundle
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected function group_changes_by_mount( array $bundle ): array {
+		$mounts = (array) ( $bundle['mounts'] ?? array() );
+
+		$changed_files_path = (string) ( $bundle['_changed_files'] ?? '' );
+		$changed_files      = array();
+		if ( '' !== $changed_files_path && is_file( $changed_files_path ) ) {
+			$decoded = json_decode( (string) file_get_contents( $changed_files_path ), true );
+			if ( is_array( $decoded ) ) {
+				$changed_files = (array) ( $decoded['files'] ?? array() );
+			}
+		}
+
+		$grouped = array();
+		foreach ( $changed_files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+			$idx   = (int) ( $file['mountIndex'] ?? -1 );
+			$path  = (string) ( $file['path'] ?? '' );
+			if ( $idx < 0 || '' === $path || ! isset( $mounts[ $idx ] ) ) {
+				continue;
+			}
+			$mount = $mounts[ $idx ];
+			if ( ( $mount['mode'] ?? '' ) !== 'readwrite' ) {
+				continue;
+			}
+
+			if ( ! isset( $grouped[ $idx ] ) ) {
+				$grouped[ $idx ] = array(
+					'mount_index'   => $idx,
+					'mount'         => $mount,
+					'changed_paths' => array(),
+				);
+			}
+			$grouped[ $idx ]['changed_paths'][] = $path;
+		}
+
+		return array_values( $grouped );
+	}
+
+	/**
+	 * Apply the patch to a single mount's repo.
+	 *
+	 * @param array  $entry       Grouped mount entry.
+	 * @param string $artifact_id
+	 * @param string $commit_hint
+	 * @param array  $bundle
+	 * @return array<string,mixed>
+	 */
+	protected function apply_to_mount( array $entry, string $artifact_id, string $commit_hint, array $bundle ): array {
+		$mount    = (array) $entry['mount'];
+		$metadata = (array) ( $mount['metadata'] ?? array() );
+		$slug     = (string) ( $metadata['slug'] ?? '' );
+		$repo     = (string) ( $metadata['repo'] ?? '' );
+
+		if ( '' === $slug || '' === $repo ) {
+			return array(
+				'success' => false,
+				'slug'    => $slug,
+				'repo'    => $repo,
+				'error'   => 'Mount missing slug or repo metadata.',
+			);
+		}
+
+		$default_branch = (string) ( $metadata['default_branch'] ?? 'main' );
+		$branch         = $this->build_branch_name( $artifact_id, $slug );
+		$workspace_root = extrachill_roadie_workspace_root();
+		$primary_path   = $workspace_root . '/' . $slug;
+		$worktree_slug  = $this->branch_to_slug( $branch );
+		$worktree_path  = $workspace_root . '/' . $slug . '@' . $worktree_slug;
+
+		if ( ! is_dir( $primary_path ) ) {
+			return array(
+				'success' => false,
+				'slug'    => $slug,
+				'repo'    => $repo,
+				'error'   => 'Workspace primary clone is missing: ' . $primary_path,
+			);
+		}
+
+		// 1. Create a fresh worktree via DMC.
+		$worktree = $this->run_command(
+			sprintf(
+				'wp --allow-root --path=%s datamachine-code workspace worktree add %s %s --from=%s --skip-bootstrap --skip-context-injection 2>&1',
+				escapeshellarg( ABSPATH ),
+				escapeshellarg( $slug ),
+				escapeshellarg( $branch ),
+				escapeshellarg( 'origin/' . $default_branch )
+			)
+		);
+		if ( 0 !== $worktree['exit_code'] && ! is_dir( $worktree_path ) ) {
+			return array(
+				'success' => false,
+				'slug'    => $slug,
+				'repo'    => $repo,
+				'branch'  => $branch,
+				'error'   => 'Failed to create worktree: ' . $worktree['output'],
+			);
+		}
+
+		// 2. Translate sandbox paths in patch back to host paths.
+		// captureMountDiffs writes diffs under files/diffs/mount-<idx>.patch
+		// already scoped to one mount. Prefer that over the combined patch.
+		$idx               = (int) $entry['mount_index'];
+		$mount_patch_path  = $bundle['_bundle_dir'] . '/files/diffs/mount-' . $idx . '.patch';
+		$patch_source      = is_file( $mount_patch_path ) ? $mount_patch_path : (string) ( $bundle['_patch_path'] ?? '' );
+
+		if ( '' === $patch_source || ! is_file( $patch_source ) ) {
+			return array(
+				'success' => false,
+				'slug'    => $slug,
+				'repo'    => $repo,
+				'branch'  => $branch,
+				'error'   => 'Patch file missing for mount index ' . $idx,
+			);
+		}
+
+		$patch_contents = (string) file_get_contents( $patch_source );
+		$translated     = $this->translate_patch_paths( $patch_contents, (string) $mount['target'] );
+		$tmp_patch      = tempnam( sys_get_temp_dir(), 'roadie-patch-' );
+		file_put_contents( $tmp_patch, $translated );
+
+		// 3. Apply the patch inside the worktree.
+		$apply = $this->run_command(
+			sprintf(
+				'cd %s && git apply --whitespace=nowarn %s 2>&1',
+				escapeshellarg( $worktree_path ),
+				escapeshellarg( $tmp_patch )
+			)
+		);
+		@unlink( $tmp_patch );
+
+		if ( 0 !== $apply['exit_code'] ) {
+			return array(
+				'success'       => false,
+				'slug'          => $slug,
+				'repo'          => $repo,
+				'branch'        => $branch,
+				'worktree_path' => $worktree_path,
+				'error'         => 'git apply failed: ' . $apply['output'],
+			);
+		}
+
+		// 4. Commit.
+		$commit_message = $this->build_commit_message( $commit_hint, $bundle, $slug );
+		$commit         = $this->run_command(
+			sprintf(
+				'cd %s && git add -A && git -c user.email=%s -c user.name=%s commit -m %s 2>&1',
+				escapeshellarg( $worktree_path ),
+				escapeshellarg( $this->commit_email() ),
+				escapeshellarg( $this->commit_name() ),
+				escapeshellarg( $commit_message )
+			)
+		);
+		if ( 0 !== $commit['exit_code'] ) {
+			return array(
+				'success'       => false,
+				'slug'          => $slug,
+				'repo'          => $repo,
+				'branch'        => $branch,
+				'worktree_path' => $worktree_path,
+				'error'         => 'git commit failed: ' . $commit['output'],
+			);
+		}
+
+		// 5. Push.
+		$push = $this->run_command(
+			sprintf(
+				'cd %s && git push -u origin %s 2>&1',
+				escapeshellarg( $worktree_path ),
+				escapeshellarg( $branch )
+			)
+		);
+		if ( 0 !== $push['exit_code'] ) {
+			return array(
+				'success'       => false,
+				'slug'          => $slug,
+				'repo'          => $repo,
+				'branch'        => $branch,
+				'worktree_path' => $worktree_path,
+				'error'         => 'git push failed: ' . $push['output'],
+			);
+		}
+
+		// 6. Open PR.
+		$proposer_id   = (int) ( $bundle['context']['proposer_user_id'] ?? 0 );
+		$proposer_line = $proposer_id > 0 ? sprintf( "\n\nProposed via roadie chat by user %d.", $proposer_id ) : '';
+		$pr_body       = $commit_message . $proposer_line . "\n\nArtifact id: `" . $bundle['id'] . "`";
+
+		$pr = $this->run_command(
+			sprintf(
+				'cd %s && gh pr create --repo %s --base %s --head %s --title %s --body %s 2>&1',
+				escapeshellarg( $worktree_path ),
+				escapeshellarg( $repo ),
+				escapeshellarg( $default_branch ),
+				escapeshellarg( $branch ),
+				escapeshellarg( $commit_message ),
+				escapeshellarg( $pr_body )
+			)
+		);
+		if ( 0 !== $pr['exit_code'] ) {
+			return array(
+				'success'       => false,
+				'slug'          => $slug,
+				'repo'          => $repo,
+				'branch'        => $branch,
+				'worktree_path' => $worktree_path,
+				'error'         => 'gh pr create failed: ' . $pr['output'],
+			);
+		}
+
+		$pr_url = $this->extract_pr_url( $pr['output'] );
+
+		return array(
+			'success'       => true,
+			'slug'          => $slug,
+			'repo'          => $repo,
+			'branch'        => $branch,
+			'worktree_path' => $worktree_path,
+			'pr_url'        => $pr_url,
+			'changed_paths' => $entry['changed_paths'],
+		);
+	}
+
+	/**
+	 * Run a shell command and capture exit code + combined output.
+	 *
+	 * @param string $cmd
+	 * @return array{exit_code:int,output:string}
+	 */
+	protected function run_command( string $cmd ): array {
+		$output = array();
+		$code   = 1;
+		exec( $cmd, $output, $code );
+		return array(
+			'exit_code' => (int) $code,
+			'output'    => implode( "\n", $output ),
+		);
+	}
+
+	/**
+	 * Rewrite a unified diff so sandbox paths like
+	 * `/wordpress/wp-content/plugins/<slug>/foo.php` become repo-root-relative
+	 * `foo.php`, matching the on-disk layout of the workspace clone.
+	 *
+	 * @param string $patch
+	 * @param string $sandbox_target Mount target inside sandbox, e.g.
+	 *                                /wordpress/wp-content/plugins/<slug>
+	 * @return string
+	 */
+	protected function translate_patch_paths( string $patch, string $sandbox_target ): string {
+		$prefix = ltrim( $sandbox_target, '/' );
+
+		// Patch lines look like:  diff --git a/wordpress/wp-content/plugins/foo/file.php b/wordpress/...
+		//                         --- a/wordpress/...
+		//                         +++ b/wordpress/...
+		$patterns = array(
+			'#^(diff --git )a/' . preg_quote( $prefix, '#' ) . '/(.+) b/' . preg_quote( $prefix, '#' ) . '/(.+)$#m',
+			'#^(--- )a/' . preg_quote( $prefix, '#' ) . '/(.+)$#m',
+			'#^(\+\+\+ )b/' . preg_quote( $prefix, '#' ) . '/(.+)$#m',
+		);
+		$replacements = array(
+			'$1a/$2 b/$3',
+			'$1a/$2',
+			'$1b/$2',
+		);
+
+		return (string) preg_replace( $patterns, $replacements, $patch );
+	}
+
+	/**
+	 * Build a branch name unique to this artifact + slug.
+	 *
+	 * @param string $artifact_id
+	 * @param string $slug
+	 * @return string
+	 */
+	protected function build_branch_name( string $artifact_id, string $slug ): string {
+		$short = substr( preg_replace( '/[^a-z0-9]+/i', '', $artifact_id ), 0, 12 );
+		return sprintf( 'roadie/%s-%s', $slug, strtolower( $short ) );
+	}
+
+	/**
+	 * Convert a branch name to the worktree slug DMC uses on disk.
+	 *
+	 * Per DMC convention: slashes become dashes in the slug.
+	 *
+	 * @param string $branch
+	 * @return string
+	 */
+	protected function branch_to_slug( string $branch ): string {
+		return str_replace( '/', '-', $branch );
+	}
+
+	/**
+	 * Build the conventional-commit message.
+	 *
+	 * @param string $hint
+	 * @param array  $bundle
+	 * @param string $slug
+	 * @return string
+	 */
+	protected function build_commit_message( string $hint, array $bundle, string $slug ): string {
+		if ( '' !== $hint ) {
+			return $hint;
+		}
+		$summary = '';
+		$review_path = $bundle['_bundle_dir'] . '/files/review.json';
+		if ( is_file( $review_path ) ) {
+			$decoded = json_decode( (string) file_get_contents( $review_path ), true );
+			if ( is_array( $decoded ) ) {
+				$summary = trim( (string) ( $decoded['summary'] ?? '' ) );
+			}
+		}
+		if ( '' === $summary ) {
+			$summary = 'roadie sandbox change';
+		}
+		// First line only, prefix as fix(<slug>): or feat(<slug>): if not already conventional.
+		$first = strtok( $summary, "\n" );
+		if ( $first === false ) {
+			$first = $summary;
+		}
+		if ( ! preg_match( '/^(fix|feat|refactor|chore|docs|test|build|ci|perf|style)(\(.+\))?:/', $first ) ) {
+			$first = sprintf( 'fix(%s): %s', $slug, $first );
+		}
+		return $first;
+	}
+
+	protected function commit_name(): string {
+		return (string) apply_filters( 'extrachill_roadie_apply_commit_name', 'Extra Chill Bot' );
+	}
+
+	protected function commit_email(): string {
+		return (string) apply_filters( 'extrachill_roadie_apply_commit_email', 'bot@extrachill.com' );
+	}
+
+	protected function extract_pr_url( string $output ): string {
+		if ( preg_match( '#https://github\.com/[^\s]+/pull/\d+#', $output, $m ) ) {
+			return $m[0];
+		}
+		return '';
+	}
+}

--- a/inc/tools/class-propose-code-change.php
+++ b/inc/tools/class-propose-code-change.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Propose Code Change Tool
+ *
+ * Chat tool that dispatches a WP Codebox sandbox to make a bounded code
+ * change against the current subsite's stack and open a PR.
+ *
+ * Flow:
+ *   1. Resolve the current subsite context (theme + subsite-specific plugins).
+ *   2. Build a recipe (mounts) from the slug → repo map.
+ *   3. Invoke `wp-codebox/run-agent-task` with the recipe, the user's
+ *      task description, `preview_hold_seconds=900`, and the env var name
+ *      for `GITHUB_TOKEN`.
+ *   4. Surface the artifact bundle metadata + preview URL back to chat.
+ *
+ * Per the WP Codebox `secret_env` contract, only the env var NAME is passed
+ * in the ability input. The actual token value must be in the parent PHP
+ * process environment (typically set via `wp-config.php` `putenv()`).
+ *
+ * @package ExtraChillRoadie\Tools
+ * @since 0.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class ECRoadie_ProposeCodeChange extends BaseTool {
+
+	protected string $tool_slug = 'propose_code_change';
+
+	public function __construct() {
+		$this->registerTool(
+			$this->tool_slug,
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'access_level' => 'authenticated' )
+		);
+	}
+
+	/**
+	 * Tool definition.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'When the user describes a code change they want made to this site (a typo fix, copy change, a small feature, etc.), use this tool to dispatch a sandboxed coding agent that implements the change in an isolated WordPress Playground, captures an artifact bundle, and opens a pull request on GitHub for human review. The user does not need shell access or git knowledge. Only call this when the user explicitly asks for a code change. The PR URL surfaces in the response.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'task_description' ),
+				'properties' => array(
+					'task_description' => array(
+						'type'        => 'string',
+						'description' => 'Natural-language description of the code change to make. Include enough context that a coding agent could implement it without further questions — what to change, where (file/component/page if known), and the desired outcome.',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tool callback.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Resolved tool definition (unused).
+	 * @return array<string,mixed>
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		unset( $tool_def );
+
+		// 1. Capability check.
+		if ( ! current_user_can( EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ) ) {
+			return $this->buildErrorResponse(
+				'You do not have permission to propose code changes. Ask an administrator to grant the "extrachill_propose_code" capability.',
+				$this->tool_slug
+			);
+		}
+
+		$task_description = trim( (string) ( $parameters['task_description'] ?? '' ) );
+		if ( '' === $task_description ) {
+			return $this->buildErrorResponse(
+				'task_description is required. Describe the change you want made.',
+				$this->tool_slug
+			);
+		}
+
+		// 2. Verify the wp-codebox ability is available.
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return $this->buildErrorResponse(
+				'The WordPress Abilities API is not available on this site. The contribute-code flow requires it.',
+				$this->tool_slug
+			);
+		}
+
+		$ability = wp_get_ability( 'wp-codebox/run-agent-task' );
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				'The `wp-codebox/run-agent-task` ability is not registered. Install and activate the wp-codebox plugin on this network.',
+				$this->tool_slug
+			);
+		}
+
+		// 3. Verify the platform bot token env var is set in the parent process.
+		if ( ! extrachill_roadie_github_token_is_present() ) {
+			$env_name    = extrachill_roadie_github_token_env_name();
+			$option_name = extrachill_roadie_github_token_option_name();
+			return $this->buildDiagnosticErrorResponse(
+				sprintf(
+					'GitHub token is not configured. The env var "%s" must be set in the WordPress PHP process environment (typically via `putenv()` in `wp-config.php` or a `.env` file). The env var name itself can be overridden via the network option "%s" or the `extrachill_roadie_github_token_env_name` filter.',
+					$env_name,
+					$option_name
+				),
+				'configuration',
+				$this->tool_slug,
+				array(),
+				array(
+					'action'    => 'Configure GitHub token',
+					'message'   => sprintf( 'Set %s in wp-config.php with putenv(). See docs/contribute-code.md for the setup walkthrough.', $env_name ),
+					'tool_hint' => $this->tool_slug,
+				)
+			);
+		}
+
+		// 4. Detect subsite context + build recipe.
+		$context = extrachill_roadie_detect_subsite_context();
+		$recipe  = extrachill_roadie_build_recipe( $context, extrachill_roadie_default_repo_map() );
+
+		if ( empty( $recipe['mounts'] ) ) {
+			return $this->buildErrorResponse(
+				'No editable mounts could be built for this subsite. Check the slug-to-repo map (`extrachill_roadie_repo_map` filter) covers this site\'s theme and plugins.',
+				$this->tool_slug
+			);
+		}
+
+		// 5. Build the goal text the sandboxed agent sees. Include subsite
+		// context so the agent knows which subsite triggered the change.
+		$goal = $this->build_sandbox_goal( $task_description, $context, $recipe );
+
+		// 6. Invoke the ability.
+		$preview_hold = (int) apply_filters( 'extrachill_roadie_preview_hold_seconds', 900 );
+		$input        = array(
+			'goal'                 => $goal,
+			'mounts'               => $recipe['mounts'],
+			'secret_env'           => array( extrachill_roadie_github_token_env_name() ),
+			'preview_hold_seconds' => max( 0, min( 3600, $preview_hold ) ),
+			'expected_artifacts'   => array( 'patch', 'review', 'preview' ),
+			'context'              => array(
+				'consumer'         => 'extrachill-roadie',
+				'subsite'          => array(
+					'blog_id'  => (int) ( $context['blog_id'] ?? 0 ),
+					'site_url' => (string) ( $context['site_url'] ?? '' ),
+				),
+				'editable_targets' => $recipe['editable_targets'],
+				'unmapped_plugins' => $recipe['unmapped_active_plugins'],
+				'proposer_user_id' => function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0,
+			),
+		);
+
+		/**
+		 * Filter the input passed to `wp-codebox/run-agent-task`.
+		 *
+		 * @since 0.7.0
+		 *
+		 * @param array $input   Ability input.
+		 * @param array $context Subsite context.
+		 * @param array $recipe  Built recipe.
+		 */
+		$input = (array) apply_filters( 'extrachill_roadie_propose_code_input', $input, $context, $recipe );
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				'Sandbox dispatch failed: ' . $result->get_error_message(),
+				$this->tool_slug
+			);
+		}
+
+		if ( ! is_array( $result ) ) {
+			return $this->buildErrorResponse(
+				'Unexpected response from wp-codebox/run-agent-task.',
+				$this->tool_slug
+			);
+		}
+
+		return array(
+			'success'   => (bool) ( $result['success'] ?? false ),
+			'tool_name' => $this->tool_slug,
+			'data'      => $this->shape_chat_response( $result, $context, $recipe ),
+		);
+	}
+
+	/**
+	 * Compose the sandbox goal string.
+	 *
+	 * Prepends a short framing so the sandboxed agent knows which subsite
+	 * the change originated from and which mounts are editable.
+	 *
+	 * @param string $task_description User's natural-language request.
+	 * @param array  $context          Subsite context.
+	 * @param array  $recipe           Built recipe.
+	 * @return string
+	 */
+	protected function build_sandbox_goal( string $task_description, array $context, array $recipe ): string {
+		$lines   = array();
+		$lines[] = sprintf(
+			'Contribution proposed via roadie chat on %s (blog %d).',
+			(string) ( $context['site_url'] ?? 'unknown site' ),
+			(int) ( $context['blog_id'] ?? 0 )
+		);
+
+		$editable = array_keys( (array) ( $recipe['editable_targets'] ?? array() ) );
+		if ( ! empty( $editable ) ) {
+			$lines[] = 'Editable components mounted readwrite: ' . implode( ', ', $editable ) . '.';
+		}
+
+		$agent_stack = array_keys( (array) ( $recipe['agent_stack_targets'] ?? array() ) );
+		if ( ! empty( $agent_stack ) ) {
+			$lines[] = 'Agent stack mounted readonly (reference only, do not edit): ' . implode( ', ', $agent_stack ) . '.';
+		}
+
+		$lines[] = '';
+		$lines[] = 'Task from the proposer:';
+		$lines[] = $task_description;
+		$lines[] = '';
+		$lines[] = 'When the change is implemented, commit with conventional-commit style messages, push the branch, and open a pull request against the appropriate repo (use the `metadata.repo` of the mount you edited). Never edit readonly mounts. Never hand-bump version strings or CHANGELOG.md (homeboy owns both).';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Shape the wp-codebox response into a chat-friendly payload.
+	 *
+	 * Picks summary, changed files, preview URL, and PR URL out of the
+	 * artifact bundle metadata. Whatever the sandbox put in `run` or
+	 * `artifacts` is surfaced verbatim under `raw` for debugging.
+	 *
+	 * @param array $result  Ability result.
+	 * @param array $context Subsite context.
+	 * @param array $recipe  Recipe.
+	 * @return array<string,mixed>
+	 */
+	protected function shape_chat_response( array $result, array $context, array $recipe ): array {
+		$run         = (array) ( $result['run'] ?? array() );
+		$artifacts   = $result['artifacts'] ?? '';
+		$paths       = (array) ( $result['paths'] ?? array() );
+
+		// Try a few well-known keys the sandbox might publish.
+		$preview_url = (string) ( $run['preview_url'] ?? $run['preview']['url'] ?? '' );
+		$pr_url      = (string) ( $run['pr_url'] ?? $run['pull_request']['url'] ?? '' );
+		$summary     = (string) ( $run['summary'] ?? $run['review']['summary'] ?? '' );
+		$changed     = (array) ( $run['changed_files'] ?? $run['review']['changed_files'] ?? array() );
+
+		return array(
+			'summary'       => $summary,
+			'preview_url'   => $preview_url,
+			'pr_url'        => $pr_url,
+			'changed_files' => $changed,
+			'artifact'      => array(
+				'id'             => (string) ( $run['artifact_id'] ?? '' ),
+				'artifacts_path' => is_string( $artifacts ) ? $artifacts : '',
+				'paths'          => $paths,
+			),
+			'subsite'       => array(
+				'blog_id'  => (int) ( $context['blog_id'] ?? 0 ),
+				'site_url' => (string) ( $context['site_url'] ?? '' ),
+			),
+			'editable_targets' => $recipe['editable_targets'],
+			'raw'           => $result,
+		);
+	}
+}

--- a/inc/tools/class-propose-code-change.php
+++ b/inc/tools/class-propose-code-change.php
@@ -3,19 +3,25 @@
  * Propose Code Change Tool
  *
  * Chat tool that dispatches a WP Codebox sandbox to make a bounded code
- * change against the current subsite's stack and open a PR.
+ * change against the current subsite's stack. The sandbox produces an
+ * artifact bundle (patch.diff + review.json + preview URL). It does NOT
+ * push code or open a PR — that's the apply_code_change tool's job, gated
+ * on explicit human approval in chat.
  *
  * Flow:
- *   1. Resolve the current subsite context (theme + subsite-specific plugins).
- *   2. Build a recipe (mounts) from the slug → repo map.
- *   3. Invoke `wp-codebox/run-agent-task` with the recipe, the user's
- *      task description, `preview_hold_seconds=900`, and the env var name
- *      for `GITHUB_TOKEN`.
- *   4. Surface the artifact bundle metadata + preview URL back to chat.
+ *   1. Capability check (extrachill_propose_code).
+ *   2. Detect subsite context.
+ *   3. Build recipe (mounts from /var/lib/datamachine/workspace/<repo>).
+ *   4. Invoke wp-codebox/run-agent-task with:
+ *       - the recipe mounts
+ *       - inherit.connectors=['openai'] (resolves provider/model/secret_env
+ *         via our wp_codebox_resolve_inheritance filter)
+ *       - preview_hold_seconds=900
+ *   5. Return artifact_id + preview_url + summary + changed_files to chat
+ *      so the user can review and explicitly approve.
  *
- * Per the WP Codebox `secret_env` contract, only the env var NAME is passed
- * in the ability input. The actual token value must be in the parent PHP
- * process environment (typically set via `wp-config.php` `putenv()`).
+ * No GitHub token, no git operations, no PR. That all lives in
+ * apply_code_change.
  *
  * @package ExtraChillRoadie\Tools
  * @since 0.7.0
@@ -49,7 +55,7 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'When the user describes a code change they want made to this site (a typo fix, copy change, a small feature, etc.), use this tool to dispatch a sandboxed coding agent that implements the change in an isolated WordPress Playground, captures an artifact bundle, and opens a pull request on GitHub for human review. The user does not need shell access or git knowledge. Only call this when the user explicitly asks for a code change. The PR URL surfaces in the response.',
+			'description' => 'When the user describes a code change they want made to this site (a typo fix, copy change, a small feature, etc.), use this tool to dispatch a sandboxed coding agent that implements the change in an isolated WordPress Playground. The sandbox produces a reviewable patch artifact and a live preview URL — it does NOT push code or open a pull request. After this tool returns, surface the preview URL and summary to the user and ask them to approve. When the user approves, call apply_code_change with the returned artifact_id to commit the change and open a PR.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'required'   => array( 'task_description' ),
@@ -105,48 +111,38 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 			);
 		}
 
-		// 3. Verify the platform bot token env var is set in the parent process.
-		if ( ! extrachill_roadie_github_token_is_present() ) {
-			$env_name    = extrachill_roadie_github_token_env_name();
-			$option_name = extrachill_roadie_github_token_option_name();
-			return $this->buildDiagnosticErrorResponse(
-				sprintf(
-					'GitHub token is not configured. The env var "%s" must be set in the WordPress PHP process environment (typically via `putenv()` in `wp-config.php` or a `.env` file). The env var name itself can be overridden via the network option "%s" or the `extrachill_roadie_github_token_env_name` filter.',
-					$env_name,
-					$option_name
-				),
-				'configuration',
-				$this->tool_slug,
-				array(),
-				array(
-					'action'    => 'Configure GitHub token',
-					'message'   => sprintf( 'Set %s in wp-config.php with putenv(). See docs/contribute-code.md for the setup walkthrough.', $env_name ),
-					'tool_hint' => $this->tool_slug,
-				)
-			);
-		}
-
-		// 4. Detect subsite context + build recipe.
+		// 3. Detect subsite context + build recipe.
 		$context = extrachill_roadie_detect_subsite_context();
 		$recipe  = extrachill_roadie_build_recipe( $context, extrachill_roadie_default_repo_map() );
 
 		if ( empty( $recipe['mounts'] ) ) {
+			$missing = $recipe['missing_clones'] ?? array();
+			$detail  = '';
+			if ( ! empty( $missing ) ) {
+				$detail = ' Missing workspace clones for: ' . implode( ', ', $missing ) . '. Run `wp datamachine-code workspace clone <repo>` for each.';
+			}
 			return $this->buildErrorResponse(
-				'No editable mounts could be built for this subsite. Check the slug-to-repo map (`extrachill_roadie_repo_map` filter) covers this site\'s theme and plugins.',
+				'No editable mounts could be built for this subsite.' . $detail . ' Check the slug-to-repo map (`extrachill_roadie_repo_map` filter) covers this site\'s theme and plugins.',
 				$this->tool_slug
 			);
 		}
 
-		// 5. Build the goal text the sandboxed agent sees. Include subsite
-		// context so the agent knows which subsite triggered the change.
+		// 4. Build the sandbox goal.
 		$goal = $this->build_sandbox_goal( $task_description, $context, $recipe );
 
-		// 6. Invoke the ability.
+		// 5. Invoke the ability.
 		$preview_hold = (int) apply_filters( 'extrachill_roadie_preview_hold_seconds', 900 );
-		$input        = array(
+		$connectors   = (array) apply_filters( 'extrachill_roadie_inherit_connector_names', array( 'openai' ) );
+
+		$input = array(
 			'goal'                 => $goal,
 			'mounts'               => $recipe['mounts'],
-			'secret_env'           => array( extrachill_roadie_github_token_env_name() ),
+			'inherit'              => array(
+				// Connector names resolved by our wp_codebox_resolve_inheritance
+				// filter. The filter populates provider/model/secretEnv and
+				// putenvs credential values on the host PHP process.
+				'connectors' => array_values( array_filter( array_map( 'strval', $connectors ) ) ),
+			),
 			'preview_hold_seconds' => max( 0, min( 3600, $preview_hold ) ),
 			'expected_artifacts'   => array( 'patch', 'review', 'preview' ),
 			'context'              => array(
@@ -198,8 +194,10 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 	/**
 	 * Compose the sandbox goal string.
 	 *
-	 * Prepends a short framing so the sandboxed agent knows which subsite
-	 * the change originated from and which mounts are editable.
+	 * The sandbox agent has no other context than what we put here, so be
+	 * explicit about: which subsite triggered the change, which mounts are
+	 * editable, the user's task, and the hard constraints (don't push, don't
+	 * touch CHANGELOG/versions, conventional commits).
 	 *
 	 * @param string $task_description User's natural-language request.
 	 * @param array  $context          Subsite context.
@@ -219,16 +217,11 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 			$lines[] = 'Editable components mounted readwrite: ' . implode( ', ', $editable ) . '.';
 		}
 
-		$agent_stack = array_keys( (array) ( $recipe['agent_stack_targets'] ?? array() ) );
-		if ( ! empty( $agent_stack ) ) {
-			$lines[] = 'Agent stack mounted readonly (reference only, do not edit): ' . implode( ', ', $agent_stack ) . '.';
-		}
-
 		$lines[] = '';
 		$lines[] = 'Task from the proposer:';
 		$lines[] = $task_description;
 		$lines[] = '';
-		$lines[] = 'When the change is implemented, commit with conventional-commit style messages, push the branch, and open a pull request against the appropriate repo (use the `metadata.repo` of the mount you edited). Never edit readonly mounts. Never hand-bump version strings or CHANGELOG.md (homeboy owns both).';
+		$lines[] = 'Implement the change against the editable mounts only. Do not push code, do not open a pull request — those happen on the host after a human approves your patch. Never edit CHANGELOG.md, never hand-bump version strings (homeboy owns both). Use conventional commit message styling in any commit messages you author (fix:, feat:, refactor:, etc.) even though the actual commit will be made by the apply-back tool.';
 
 		return implode( "\n", $lines );
 	}
@@ -236,9 +229,10 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 	/**
 	 * Shape the wp-codebox response into a chat-friendly payload.
 	 *
-	 * Picks summary, changed files, preview URL, and PR URL out of the
-	 * artifact bundle metadata. Whatever the sandbox put in `run` or
-	 * `artifacts` is surfaced verbatim under `raw` for debugging.
+	 * Returns artifact_id, preview_url, summary, changed_files, and the list
+	 * of mounts that actually had changes — enough for chat to render a
+	 * "ready for review" message with an explicit approve step that hands
+	 * artifact_id to apply_code_change.
 	 *
 	 * @param array $result  Ability result.
 	 * @param array $context Subsite context.
@@ -248,30 +242,50 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 	protected function shape_chat_response( array $result, array $context, array $recipe ): array {
 		$run         = (array) ( $result['run'] ?? array() );
 		$artifacts   = $result['artifacts'] ?? '';
-		$paths       = (array) ( $result['paths'] ?? array() );
 
-		// Try a few well-known keys the sandbox might publish.
-		$preview_url = (string) ( $run['preview_url'] ?? $run['preview']['url'] ?? '' );
-		$pr_url      = (string) ( $run['pr_url'] ?? $run['pull_request']['url'] ?? '' );
-		$summary     = (string) ( $run['summary'] ?? $run['review']['summary'] ?? '' );
-		$changed     = (array) ( $run['changed_files'] ?? $run['review']['changed_files'] ?? array() );
+		// wp-codebox publishes preview URL under run.artifacts.preview.url
+		// per its README; we also accept a few fallback shapes.
+		$preview_url = (string) (
+			$run['artifacts']['preview']['url']
+				?? $run['preview']['url']
+				?? $run['preview_url']
+				?? ''
+		);
+
+		$artifact_id = (string) (
+			$run['artifact']['id']
+				?? $run['artifact_id']
+				?? $run['manifest']['id']
+				?? ''
+		);
+
+		$review      = (array) ( $run['artifact']['review'] ?? $run['review'] ?? array() );
+		$summary     = (string) ( $review['summary'] ?? $run['summary'] ?? '' );
+		$changed     = (array) ( $review['changed_files']
+			?? $run['changed_files']
+			?? $run['artifact']['changed_files']
+			?? array() );
 
 		return array(
-			'summary'       => $summary,
-			'preview_url'   => $preview_url,
-			'pr_url'        => $pr_url,
-			'changed_files' => $changed,
-			'artifact'      => array(
-				'id'             => (string) ( $run['artifact_id'] ?? '' ),
-				'artifacts_path' => is_string( $artifacts ) ? $artifacts : '',
-				'paths'          => $paths,
-			),
-			'subsite'       => array(
+			'status'           => 'pending-approval',
+			'artifact_id'      => $artifact_id,
+			'preview_url'      => $preview_url,
+			'summary'          => $summary,
+			'changed_files'    => $changed,
+			'subsite'          => array(
 				'blog_id'  => (int) ( $context['blog_id'] ?? 0 ),
 				'site_url' => (string) ( $context['site_url'] ?? '' ),
 			),
 			'editable_targets' => $recipe['editable_targets'],
-			'raw'           => $result,
+			'next_step'        => sprintf(
+				'Review the changes at the preview URL. If they look good, call apply_code_change with artifact_id="%s" to commit and open a pull request. To discard, call wp-codebox/discard-artifact.',
+				$artifact_id
+			),
+			'artifact'         => array(
+				'id'             => $artifact_id,
+				'artifacts_path' => is_string( $artifacts ) ? $artifacts : '',
+			),
+			'raw'              => $result,
 		);
 	}
 }

--- a/inc/tools/register.php
+++ b/inc/tools/register.php
@@ -36,11 +36,13 @@ add_action(
 		require_once __DIR__ . '/class-manage-user-profile.php';
 		require_once __DIR__ . '/class-manage-community.php';
 		require_once __DIR__ . '/class-propose-code-change.php';
+		require_once __DIR__ . '/class-apply-code-change.php';
 
 		new ECRoadie_ManageArtistProfile();
 		new ECRoadie_ManageLinkPage();
 		new ECRoadie_ManageUserProfile();
 		new ECRoadie_ManageCommunity();
 		new ECRoadie_ProposeCodeChange();
+		new ECRoadie_ApplyCodeChange();
 	}
 );

--- a/inc/tools/register.php
+++ b/inc/tools/register.php
@@ -35,10 +35,12 @@ add_action(
 		require_once __DIR__ . '/class-manage-link-page.php';
 		require_once __DIR__ . '/class-manage-user-profile.php';
 		require_once __DIR__ . '/class-manage-community.php';
+		require_once __DIR__ . '/class-propose-code-change.php';
 
 		new ECRoadie_ManageArtistProfile();
 		new ECRoadie_ManageLinkPage();
 		new ECRoadie_ManageUserProfile();
 		new ECRoadie_ManageCommunity();
+		new ECRoadie_ProposeCodeChange();
 	}
 );

--- a/tests/contribute-code-bootstrap.php
+++ b/tests/contribute-code-bootstrap.php
@@ -169,3 +169,4 @@ require_once dirname( __DIR__ ) . '/inc/contribute-code/subsite-context.php';
 require_once dirname( __DIR__ ) . '/inc/contribute-code/repo-map.php';
 require_once dirname( __DIR__ ) . '/inc/contribute-code/recipe-builder.php';
 require_once dirname( __DIR__ ) . '/inc/contribute-code/capabilities.php';
+require_once dirname( __DIR__ ) . '/inc/contribute-code/inherit-resolver.php';

--- a/tests/contribute-code-bootstrap.php
+++ b/tests/contribute-code-bootstrap.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Shared bootstrap for contribute-code smoke tests.
+ *
+ * Provides stand-alone WordPress-shaped globals/functions so the
+ * contribute-code modules can be require_once'd without booting WordPress.
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+	define( 'WP_PLUGIN_DIR', '/var/www/extrachill.com/wp-content/plugins' );
+}
+
+$GLOBALS['extrachill_roadie_test_state'] = array(
+	'filters'        => array(),
+	'current_blog'   => 1,
+	'active_plugins' => array(),
+	'site_url'       => 'https://extrachill.test',
+	'current_user'   => null,
+	'user_caps'      => array(),
+	'site_options'   => array(),
+	'options'        => array(),
+	'theme'          => null,
+);
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		unset( $priority, $accepted_args );
+		$GLOBALS['extrachill_roadie_test_state']['filters'][ $hook ][] = $callback;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		foreach ( $GLOBALS['extrachill_roadie_test_state']['filters'][ $hook ] ?? array() as $callback ) {
+			$value = $callback( $value, ...$args );
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		add_filter( $hook, $callback, $priority, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'get_current_blog_id' ) ) {
+	function get_current_blog_id(): int {
+		return (int) $GLOBALS['extrachill_roadie_test_state']['current_blog'];
+	}
+}
+
+if ( ! function_exists( 'switch_to_blog' ) ) {
+	function switch_to_blog( int $blog_id ): bool {
+		$GLOBALS['extrachill_roadie_test_state']['current_blog_stack'][] = $GLOBALS['extrachill_roadie_test_state']['current_blog'];
+		$GLOBALS['extrachill_roadie_test_state']['current_blog']         = $blog_id;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'restore_current_blog' ) ) {
+	function restore_current_blog(): bool {
+		if ( ! empty( $GLOBALS['extrachill_roadie_test_state']['current_blog_stack'] ) ) {
+			$GLOBALS['extrachill_roadie_test_state']['current_blog'] = array_pop(
+				$GLOBALS['extrachill_roadie_test_state']['current_blog_stack']
+			);
+		}
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $name, $default = false ) {
+		if ( 'active_plugins' === $name ) {
+			return $GLOBALS['extrachill_roadie_test_state']['active_plugins'];
+		}
+		return $GLOBALS['extrachill_roadie_test_state']['options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'get_site_option' ) ) {
+	function get_site_option( string $name, $default = false ) {
+		return $GLOBALS['extrachill_roadie_test_state']['site_options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url(): string {
+		return (string) $GLOBALS['extrachill_roadie_test_state']['site_url'];
+	}
+}
+
+if ( ! function_exists( 'wp_get_theme' ) ) {
+	function wp_get_theme() {
+		if ( null === $GLOBALS['extrachill_roadie_test_state']['theme'] ) {
+			$GLOBALS['extrachill_roadie_test_state']['theme'] = new ECRoadie_TestTheme();
+		}
+		return $GLOBALS['extrachill_roadie_test_state']['theme'];
+	}
+}
+
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( string $cap ): bool {
+		return ! empty( $GLOBALS['extrachill_roadie_test_state']['user_caps'][ $cap ] );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return (int) ( $GLOBALS['extrachill_roadie_test_state']['current_user_id'] ?? 0 );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $flags = 0 ): string {
+		return (string) json_encode( $data, $flags );
+	}
+}
+
+if ( ! class_exists( 'ECRoadie_TestTheme' ) ) {
+	final class ECRoadie_TestTheme {
+		public string $stylesheet = 'extrachill';
+		public string $directory  = '/var/www/extrachill.com/wp-content/themes/extrachill';
+		public string $name       = 'Extra Chill';
+		public ?ECRoadie_TestTheme $parent_obj = null;
+
+		public function get_stylesheet(): string {
+			return $this->stylesheet;
+		}
+
+		public function get_stylesheet_directory(): string {
+			return $this->directory;
+		}
+
+		public function get( string $key ): string {
+			if ( 'Name' === $key ) {
+				return $this->name;
+			}
+			return '';
+		}
+
+		public function parent() {
+			return $this->parent_obj;
+		}
+	}
+}
+
+if ( ! function_exists( 'roadie_test_assert' ) ) {
+	function roadie_test_assert( bool $condition, string $message ): void {
+		if ( ! $condition ) {
+			throw new RuntimeException( $message );
+		}
+	}
+}
+
+if ( ! function_exists( 'roadie_test_reset_filters' ) ) {
+	function roadie_test_reset_filters(): void {
+		$GLOBALS['extrachill_roadie_test_state']['filters'] = array();
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/contribute-code/subsite-context.php';
+require_once dirname( __DIR__ ) . '/inc/contribute-code/repo-map.php';
+require_once dirname( __DIR__ ) . '/inc/contribute-code/recipe-builder.php';
+require_once dirname( __DIR__ ) . '/inc/contribute-code/capabilities.php';

--- a/tests/contribute-code-capabilities.php
+++ b/tests/contribute-code-capabilities.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke tests for the contribute-code capability + token resolution.
+ * Smoke tests for the contribute-code capability + apply-tool github token helpers.
  *
  * Run with: php tests/contribute-code-capabilities.php
  *
@@ -53,41 +53,34 @@ roadie_test_assert(
 	'author should receive the cap after filter override'
 );
 
-// --- env var name resolution --------------------------------------------
+// --- apply-tool GitHub token helpers (host-only, never crosses to sandbox) -
 roadie_test_reset_filters();
 roadie_test_assert(
-	'GITHUB_TOKEN' === extrachill_roadie_github_token_env_name(),
-	'default env var name should be GITHUB_TOKEN'
+	'GITHUB_TOKEN' === extrachill_roadie_apply_github_token_env_name(),
+	'default apply-back env var should be GITHUB_TOKEN'
 );
 
-$GLOBALS['extrachill_roadie_test_state']['site_options']['extrachill_roadie_github_token_env'] = 'EC_BOT_TOKEN';
+putenv( 'GITHUB_TOKEN=' );
 roadie_test_assert(
-	'EC_BOT_TOKEN' === extrachill_roadie_github_token_env_name(),
-	'network option override should resolve via get_site_option'
+	! extrachill_roadie_apply_github_token_present(),
+	'empty GITHUB_TOKEN must not count as present'
 );
 
-// --- presence check -----------------------------------------------------
-putenv( 'EC_BOT_TOKEN=' ); // empty
+putenv( 'GITHUB_TOKEN=ghp_real_token_value' );
 roadie_test_assert(
-	! extrachill_roadie_github_token_is_present(),
-	'empty env var must not count as present'
-);
-
-putenv( 'EC_BOT_TOKEN=ghp_realtoken_value' );
-roadie_test_assert(
-	extrachill_roadie_github_token_is_present(),
-	'non-empty env var must count as present'
+	extrachill_roadie_apply_github_token_present(),
+	'non-empty GITHUB_TOKEN must count as present'
 );
 
 // --- filter override of env var name ------------------------------------
-add_filter( 'extrachill_roadie_github_token_env_name', fn() => 'CUSTOM_GH_TOKEN' );
-putenv( 'CUSTOM_GH_TOKEN=hello' );
+add_filter( 'extrachill_roadie_apply_github_token_env', fn() => 'EC_BOT_GH_TOKEN' );
+putenv( 'EC_BOT_GH_TOKEN=hello' );
 roadie_test_assert(
-	'CUSTOM_GH_TOKEN' === extrachill_roadie_github_token_env_name(),
-	'filter override on env var name'
+	'EC_BOT_GH_TOKEN' === extrachill_roadie_apply_github_token_env_name(),
+	'filter override on apply-back env var name'
 );
 roadie_test_assert(
-	extrachill_roadie_github_token_is_present(),
+	extrachill_roadie_apply_github_token_present(),
 	'filter-overridden env var should be detected'
 );
 

--- a/tests/contribute-code-capabilities.php
+++ b/tests/contribute-code-capabilities.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Smoke tests for the contribute-code capability + token resolution.
+ *
+ * Run with: php tests/contribute-code-capabilities.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+
+// --- user_has_cap grant ---------------------------------------------------
+$admin_user            = new stdClass();
+$admin_user->roles     = array( 'administrator' );
+$editor_user           = new stdClass();
+$editor_user->roles    = array( 'editor' );
+$contributor_user      = new stdClass();
+$contributor_user->roles = array( 'contributor' );
+
+$allcaps_admin = extrachill_roadie_grant_propose_code_cap( array(), array(), array(), $admin_user );
+roadie_test_assert(
+	! empty( $allcaps_admin[ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] ),
+	'administrator must receive extrachill_propose_code by default'
+);
+
+$allcaps_editor = extrachill_roadie_grant_propose_code_cap( array(), array(), array(), $editor_user );
+roadie_test_assert(
+	! empty( $allcaps_editor[ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] ),
+	'editor must receive extrachill_propose_code by default'
+);
+
+$allcaps_contributor = extrachill_roadie_grant_propose_code_cap( array(), array(), array(), $contributor_user );
+roadie_test_assert(
+	empty( $allcaps_contributor[ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] ),
+	'contributor must NOT receive extrachill_propose_code by default'
+);
+
+// --- filter override expands grant ---------------------------------------
+roadie_test_reset_filters();
+add_filter(
+	'extrachill_roadie_propose_code_roles',
+	function ( array $roles ) {
+		$roles[] = 'author';
+		return $roles;
+	}
+);
+
+$author_user        = new stdClass();
+$author_user->roles = array( 'author' );
+$allcaps_author     = extrachill_roadie_grant_propose_code_cap( array(), array(), array(), $author_user );
+roadie_test_assert(
+	! empty( $allcaps_author[ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] ),
+	'author should receive the cap after filter override'
+);
+
+// --- env var name resolution --------------------------------------------
+roadie_test_reset_filters();
+roadie_test_assert(
+	'GITHUB_TOKEN' === extrachill_roadie_github_token_env_name(),
+	'default env var name should be GITHUB_TOKEN'
+);
+
+$GLOBALS['extrachill_roadie_test_state']['site_options']['extrachill_roadie_github_token_env'] = 'EC_BOT_TOKEN';
+roadie_test_assert(
+	'EC_BOT_TOKEN' === extrachill_roadie_github_token_env_name(),
+	'network option override should resolve via get_site_option'
+);
+
+// --- presence check -----------------------------------------------------
+putenv( 'EC_BOT_TOKEN=' ); // empty
+roadie_test_assert(
+	! extrachill_roadie_github_token_is_present(),
+	'empty env var must not count as present'
+);
+
+putenv( 'EC_BOT_TOKEN=ghp_realtoken_value' );
+roadie_test_assert(
+	extrachill_roadie_github_token_is_present(),
+	'non-empty env var must count as present'
+);
+
+// --- filter override of env var name ------------------------------------
+add_filter( 'extrachill_roadie_github_token_env_name', fn() => 'CUSTOM_GH_TOKEN' );
+putenv( 'CUSTOM_GH_TOKEN=hello' );
+roadie_test_assert(
+	'CUSTOM_GH_TOKEN' === extrachill_roadie_github_token_env_name(),
+	'filter override on env var name'
+);
+roadie_test_assert(
+	extrachill_roadie_github_token_is_present(),
+	'filter-overridden env var should be detected'
+);
+
+echo "contribute-code capabilities smoke passed.\n";

--- a/tests/contribute-code-inherit-resolver.php
+++ b/tests/contribute-code-inherit-resolver.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Smoke tests for the wp_codebox_resolve_inheritance bridge.
+ *
+ * Run with: php tests/contribute-code-inherit-resolver.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+
+// --- Test 1: openai connector with credential present resolves to metadata --
+$GLOBALS['extrachill_roadie_test_state']['options']['connectors_ai_openai_api_key'] = 'sk-proj-FAKE_TEST_KEY_value_123';
+putenv( 'OPENAI_API_KEY=' ); // clear
+
+$request = array(
+	'connectors' => array( 'openai' ),
+	'settings'   => array(),
+);
+$resolution = array(
+	'connectors' => array(
+		array( 'name' => 'openai', 'status' => 'unresolved' ),
+	),
+	'settings'   => array(),
+);
+
+$result = extrachill_roadie_resolve_inheritance( $resolution, $request, array() );
+
+roadie_test_assert( is_array( $result ), 'resolver must return an array' );
+roadie_test_assert( ! empty( $result['connectors'][0] ), 'connector entry must be present' );
+$openai = $result['connectors'][0];
+roadie_test_assert( 'openai' === $openai['name'], 'connector name preserved' );
+roadie_test_assert( 'resolved' === $openai['status'], 'status must be resolved when option has a value' );
+roadie_test_assert( 'openai' === $openai['provider'], 'provider populated from default map' );
+roadie_test_assert( 'gpt-5' === $openai['model'], 'model populated from default map' );
+roadie_test_assert(
+	in_array( 'OPENAI_API_KEY', $openai['secretEnv'], true ),
+	'secretEnv must include OPENAI_API_KEY'
+);
+roadie_test_assert(
+	'sk-proj-FAKE_TEST_KEY_value_123' === getenv( 'OPENAI_API_KEY' ),
+	'resolver must putenv() the credential value so wp-codebox secret_env can carry the name'
+);
+
+// --- Test 2: missing credential reports status=missing-credential -------
+$GLOBALS['extrachill_roadie_test_state']['options']['connectors_ai_openai_api_key'] = '';
+putenv( 'OPENAI_API_KEY=' );
+
+$resolution2 = array(
+	'connectors' => array(
+		array( 'name' => 'openai', 'status' => 'unresolved' ),
+	),
+	'settings'   => array(),
+);
+$result2 = extrachill_roadie_resolve_inheritance( $resolution2, $request, array() );
+roadie_test_assert(
+	'missing-credential' === ( $result2['connectors'][0]['status'] ?? '' ),
+	'empty credential must report missing-credential status'
+);
+
+// --- Test 3: unknown connector left as-is -------------------------------
+roadie_test_reset_filters();
+$resolution3 = array(
+	'connectors' => array(
+		array( 'name' => 'totally-fake-connector', 'status' => 'unresolved' ),
+	),
+	'settings'   => array(),
+);
+$result3 = extrachill_roadie_resolve_inheritance(
+	$resolution3,
+	array( 'connectors' => array( 'totally-fake-connector' ), 'settings' => array() ),
+	array()
+);
+roadie_test_assert(
+	'unresolved' === ( $result3['connectors'][0]['status'] ?? '' ),
+	'unknown connector must remain unresolved (other plugins can resolve it via the same filter)'
+);
+
+// --- Test 4: filter override of connector map ---------------------------
+roadie_test_reset_filters();
+add_filter(
+	'extrachill_roadie_inherit_connectors',
+	function ( array $map ) {
+		$map['custom'] = array(
+			'provider'   => 'custom-provider',
+			'model'      => 'custom-model-v2',
+			'secret_env' => array( 'CUSTOM_API_KEY' ),
+			'option_key' => 'my_custom_api_option',
+			'env_var'    => 'CUSTOM_API_KEY',
+		);
+		return $map;
+	}
+);
+$GLOBALS['extrachill_roadie_test_state']['options']['my_custom_api_option'] = 'custom-val';
+putenv( 'CUSTOM_API_KEY=' );
+
+$resolution4 = array(
+	'connectors' => array(
+		array( 'name' => 'custom', 'status' => 'unresolved' ),
+	),
+	'settings'   => array(),
+);
+$result4 = extrachill_roadie_resolve_inheritance(
+	$resolution4,
+	array( 'connectors' => array( 'custom' ), 'settings' => array() ),
+	array()
+);
+roadie_test_assert(
+	'resolved' === $result4['connectors'][0]['status'],
+	'filter-added connector resolves'
+);
+roadie_test_assert(
+	'custom-provider' === $result4['connectors'][0]['provider'],
+	'filter-added provider'
+);
+roadie_test_assert(
+	'custom-val' === getenv( 'CUSTOM_API_KEY' ),
+	'filter-added env var got exported'
+);
+
+// Cleanup envs we set.
+putenv( 'OPENAI_API_KEY=' );
+putenv( 'CUSTOM_API_KEY=' );
+
+echo "contribute-code inherit-resolver smoke passed.\n";

--- a/tests/contribute-code-recipe-builder.php
+++ b/tests/contribute-code-recipe-builder.php
@@ -10,6 +10,15 @@
 require_once __DIR__ . '/contribute-code-bootstrap.php';
 
 // --- Setup --------------------------------------------------------------
+// Build a fake workspace root with stubs for the components used below.
+$fake_root = sys_get_temp_dir() . '/roadie-test-workspace-' . uniqid();
+mkdir( $fake_root, 0755, true );
+foreach ( array( 'extrachill', 'extrachill-community', 'extrachill-artist-platform' ) as $slug ) {
+	mkdir( $fake_root . '/' . $slug, 0755, true );
+}
+
+add_filter( 'extrachill_roadie_workspace_root', static fn() => $fake_root );
+
 $context = array(
 	'blog_id'  => 2,
 	'site_url' => 'https://community.extrachill.test',
@@ -36,25 +45,16 @@ $context = array(
 );
 
 $repo_map = extrachill_roadie_default_repo_map();
-$recipe   = extrachill_roadie_build_recipe(
-	$context,
-	$repo_map,
-	array(
-		'agent_stack_plugin_paths' => array(
-			'data-machine'              => '/host/plugins/data-machine',
-			'data-machine-code'         => '/host/plugins/data-machine-code',
-			'agents-api'                => '/host/plugins/agents-api',
-			'ai-provider-for-openai'    => '/host/plugins/ai-provider-for-openai',
-			'ai-provider-for-anthropic' => '/host/plugins/ai-provider-for-anthropic',
-		),
-	)
-);
+$recipe   = extrachill_roadie_build_recipe( $context, $repo_map );
 
 // --- Test 1: shape ------------------------------------------------------
 roadie_test_assert( is_array( $recipe['mounts'] ), 'mounts must be an array' );
-roadie_test_assert( count( $recipe['mounts'] ) >= 2, 'recipe must contain at least theme + community mounts; got ' . count( $recipe['mounts'] ) );
+roadie_test_assert(
+	count( $recipe['mounts'] ) === 2,
+	'recipe must contain exactly theme + community mounts (no agent stack); got ' . count( $recipe['mounts'] )
+);
 
-// --- Test 2: theme mount is readwrite with correct target ----------------
+// --- Test 2: theme mount sources from workspace root, sets baselineSource ---
 $theme_mount = null;
 foreach ( $recipe['mounts'] as $m ) {
 	if ( ( $m['metadata']['kind'] ?? '' ) === 'theme' ) {
@@ -63,13 +63,23 @@ foreach ( $recipe['mounts'] as $m ) {
 	}
 }
 roadie_test_assert( null !== $theme_mount, 'theme mount must exist' );
-roadie_test_assert( '/host/themes/extrachill' === $theme_mount['source'], 'theme source path' );
-roadie_test_assert( '/wordpress/wp-content/themes/extrachill' === $theme_mount['target'], 'theme target path' );
+roadie_test_assert(
+	$fake_root . '/extrachill' === $theme_mount['source'],
+	'theme source must be workspace clone path; got ' . $theme_mount['source']
+);
+roadie_test_assert(
+	'/wordpress/wp-content/themes/extrachill' === $theme_mount['target'],
+	'theme target path'
+);
 roadie_test_assert( 'readwrite' === $theme_mount['mode'], 'theme mount must be readwrite' );
+roadie_test_assert(
+	$theme_mount['source'] === $theme_mount['metadata']['baselineSource'],
+	'theme mount must set baselineSource === source for captureMountDiffs'
+);
 roadie_test_assert( 'Extra-Chill/extrachill' === $theme_mount['metadata']['repo'], 'theme repo metadata' );
-roadie_test_assert( 'main' === $theme_mount['metadata']['default_branch'], 'theme default_branch' );
+roadie_test_assert( true === ( $theme_mount['metadata']['editable'] ?? false ), 'theme mount must be marked editable' );
 
-// --- Test 3: community plugin mount is readwrite -------------------------
+// --- Test 3: community plugin mount also from workspace + baselineSource ---
 $community_mount = null;
 foreach ( $recipe['mounts'] as $m ) {
 	if ( ( $m['metadata']['slug'] ?? '' ) === 'extrachill-community' ) {
@@ -78,10 +88,25 @@ foreach ( $recipe['mounts'] as $m ) {
 	}
 }
 roadie_test_assert( null !== $community_mount, 'community mount must exist' );
+roadie_test_assert(
+	$fake_root . '/extrachill-community' === $community_mount['source'],
+	'community source must be workspace clone path'
+);
 roadie_test_assert( 'readwrite' === $community_mount['mode'], 'community mount must be readwrite' );
-roadie_test_assert( 'Extra-Chill/extrachill-community' === $community_mount['metadata']['repo'], 'community repo' );
+roadie_test_assert(
+	$community_mount['source'] === $community_mount['metadata']['baselineSource'],
+	'community mount must set baselineSource'
+);
 
-// --- Test 4: unmapped plugin tracked, NOT mounted ------------------------
+// --- Test 4: NO agent-stack mounts in our recipe ------------------------
+foreach ( $recipe['mounts'] as $m ) {
+	roadie_test_assert(
+		( $m['metadata']['kind'] ?? '' ) !== 'agent-stack-plugin',
+		'agent-stack-plugin must NOT appear in mounts; wp-codebox handles via component paths'
+	);
+}
+
+// --- Test 5: unmapped plugin tracked, NOT mounted ------------------------
 roadie_test_assert(
 	in_array( 'some-unmapped-plugin', $recipe['unmapped_active_plugins'], true ),
 	'unmapped plugin slug must appear in unmapped_active_plugins'
@@ -93,42 +118,47 @@ foreach ( $recipe['mounts'] as $m ) {
 	);
 }
 
-// --- Test 5: agent stack is readonly -------------------------------------
-$agent_mounts = array_filter(
-	$recipe['mounts'],
-	fn( $m ) => ( $m['metadata']['kind'] ?? '' ) === 'agent-stack-plugin'
+// --- Test 6: missing workspace clone tracked, NOT mounted ---------------
+roadie_test_reset_filters();
+add_filter( 'extrachill_roadie_workspace_root', static fn() => $fake_root );
+// Add a context entry whose workspace clone doesn't exist.
+$context_missing = $context;
+$context_missing['plugins'][] = array(
+	'slug' => 'extrachill-shop',
+	'file' => 'extrachill-shop/extrachill-shop.php',
+	'path' => '/host/plugins/extrachill-shop',
+	'name' => 'Extra Chill Shop',
 );
-roadie_test_assert( count( $agent_mounts ) >= 3, 'agent stack must include at least 3 references; got ' . count( $agent_mounts ) );
-foreach ( $agent_mounts as $m ) {
-	roadie_test_assert( 'readonly' === $m['mode'], 'agent-stack mount must be readonly: ' . ( $m['metadata']['slug'] ?? '' ) );
-}
-
-// --- Test 6: editable_targets index ---------------------------------------
+$recipe_missing = extrachill_roadie_build_recipe( $context_missing, $repo_map );
 roadie_test_assert(
-	isset( $recipe['editable_targets']['extrachill'] ),
-	'editable_targets must include theme slug'
+	in_array( 'extrachill-shop', $recipe_missing['missing_clones'], true ),
+	'missing workspace clone must be tracked in missing_clones'
 );
-roadie_test_assert(
-	isset( $recipe['editable_targets']['extrachill-community'] ),
-	'editable_targets must include community slug'
-);
-
-// --- Test 7: include_agent_stack=false drops the read-only branch --------
-$recipe2 = extrachill_roadie_build_recipe(
-	$context,
-	$repo_map,
-	array( 'include_agent_stack' => false )
-);
-foreach ( $recipe2['mounts'] as $m ) {
+foreach ( $recipe_missing['mounts'] as $m ) {
 	roadie_test_assert(
-		( $m['metadata']['kind'] ?? '' ) !== 'agent-stack-plugin',
-		'include_agent_stack=false should drop agent-stack mounts'
+		( $m['metadata']['slug'] ?? '' ) !== 'extrachill-shop',
+		'mount for missing clone must not be emitted'
 	);
 }
-roadie_test_assert( empty( $recipe2['agent_stack_targets'] ), 'agent_stack_targets must be empty when disabled' );
 
-// --- Test 8: filter override on repo map adds a new mappable plugin -----
+// --- Test 7: require_clone=false bypasses the check ---------------------
+$recipe_nocheck = extrachill_roadie_build_recipe(
+	$context_missing,
+	$repo_map,
+	array( 'require_clone' => false )
+);
+$found_shop = false;
+foreach ( $recipe_nocheck['mounts'] as $m ) {
+	if ( ( $m['metadata']['slug'] ?? '' ) === 'extrachill-shop' ) {
+		$found_shop = true;
+		break;
+	}
+}
+roadie_test_assert( $found_shop, 'require_clone=false should emit mounts even when clone is missing' );
+
+// --- Test 8: filter override on repo map adds new mappable plugin -------
 roadie_test_reset_filters();
+add_filter( 'extrachill_roadie_workspace_root', static fn() => $fake_root );
 add_filter(
 	'extrachill_roadie_repo_map',
 	function ( array $map ) {
@@ -141,16 +171,25 @@ add_filter(
 		return $map;
 	}
 );
+// Create the corresponding workspace dir.
+mkdir( $fake_root . '/some-unmapped-plugin', 0755, true );
 $updated_map = extrachill_roadie_default_repo_map();
-$recipe3     = extrachill_roadie_build_recipe( $context, $updated_map );
+$recipe2     = extrachill_roadie_build_recipe( $context, $updated_map );
 $found       = false;
-foreach ( $recipe3['mounts'] as $m ) {
+foreach ( $recipe2['mounts'] as $m ) {
 	if ( ( $m['metadata']['slug'] ?? '' ) === 'some-unmapped-plugin' ) {
 		$found = true;
 		roadie_test_assert( 'readwrite' === $m['mode'], 'newly-mapped plugin should be readwrite' );
 		roadie_test_assert( 'Extra-Chill/some-unmapped-plugin' === $m['metadata']['repo'], 'newly-mapped repo' );
+		roadie_test_assert(
+			$m['source'] === $m['metadata']['baselineSource'],
+			'newly-mapped mount must also set baselineSource'
+		);
 	}
 }
 roadie_test_assert( $found, 'filter-added repo entry must produce a mount' );
+
+// Cleanup
+shell_exec( 'rm -rf ' . escapeshellarg( $fake_root ) );
 
 echo "contribute-code recipe-builder smoke passed.\n";

--- a/tests/contribute-code-recipe-builder.php
+++ b/tests/contribute-code-recipe-builder.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Smoke tests for extrachill_roadie_build_recipe().
+ *
+ * Run with: php tests/contribute-code-recipe-builder.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+
+// --- Setup --------------------------------------------------------------
+$context = array(
+	'blog_id'  => 2,
+	'site_url' => 'https://community.extrachill.test',
+	'theme'    => array(
+		'slug'        => 'extrachill',
+		'parent_slug' => '',
+		'path'        => '/host/themes/extrachill',
+		'name'        => 'Extra Chill',
+	),
+	'plugins'  => array(
+		array(
+			'slug' => 'extrachill-community',
+			'file' => 'extrachill-community/extrachill-community.php',
+			'path' => '/host/plugins/extrachill-community',
+			'name' => 'Extra Chill Community',
+		),
+		array(
+			'slug' => 'some-unmapped-plugin',
+			'file' => 'some-unmapped-plugin/main.php',
+			'path' => '/host/plugins/some-unmapped-plugin',
+			'name' => 'Some unmapped plugin',
+		),
+	),
+);
+
+$repo_map = extrachill_roadie_default_repo_map();
+$recipe   = extrachill_roadie_build_recipe(
+	$context,
+	$repo_map,
+	array(
+		'agent_stack_plugin_paths' => array(
+			'data-machine'              => '/host/plugins/data-machine',
+			'data-machine-code'         => '/host/plugins/data-machine-code',
+			'agents-api'                => '/host/plugins/agents-api',
+			'ai-provider-for-openai'    => '/host/plugins/ai-provider-for-openai',
+			'ai-provider-for-anthropic' => '/host/plugins/ai-provider-for-anthropic',
+		),
+	)
+);
+
+// --- Test 1: shape ------------------------------------------------------
+roadie_test_assert( is_array( $recipe['mounts'] ), 'mounts must be an array' );
+roadie_test_assert( count( $recipe['mounts'] ) >= 2, 'recipe must contain at least theme + community mounts; got ' . count( $recipe['mounts'] ) );
+
+// --- Test 2: theme mount is readwrite with correct target ----------------
+$theme_mount = null;
+foreach ( $recipe['mounts'] as $m ) {
+	if ( ( $m['metadata']['kind'] ?? '' ) === 'theme' ) {
+		$theme_mount = $m;
+		break;
+	}
+}
+roadie_test_assert( null !== $theme_mount, 'theme mount must exist' );
+roadie_test_assert( '/host/themes/extrachill' === $theme_mount['source'], 'theme source path' );
+roadie_test_assert( '/wordpress/wp-content/themes/extrachill' === $theme_mount['target'], 'theme target path' );
+roadie_test_assert( 'readwrite' === $theme_mount['mode'], 'theme mount must be readwrite' );
+roadie_test_assert( 'Extra-Chill/extrachill' === $theme_mount['metadata']['repo'], 'theme repo metadata' );
+roadie_test_assert( 'main' === $theme_mount['metadata']['default_branch'], 'theme default_branch' );
+
+// --- Test 3: community plugin mount is readwrite -------------------------
+$community_mount = null;
+foreach ( $recipe['mounts'] as $m ) {
+	if ( ( $m['metadata']['slug'] ?? '' ) === 'extrachill-community' ) {
+		$community_mount = $m;
+		break;
+	}
+}
+roadie_test_assert( null !== $community_mount, 'community mount must exist' );
+roadie_test_assert( 'readwrite' === $community_mount['mode'], 'community mount must be readwrite' );
+roadie_test_assert( 'Extra-Chill/extrachill-community' === $community_mount['metadata']['repo'], 'community repo' );
+
+// --- Test 4: unmapped plugin tracked, NOT mounted ------------------------
+roadie_test_assert(
+	in_array( 'some-unmapped-plugin', $recipe['unmapped_active_plugins'], true ),
+	'unmapped plugin slug must appear in unmapped_active_plugins'
+);
+foreach ( $recipe['mounts'] as $m ) {
+	roadie_test_assert(
+		( $m['metadata']['slug'] ?? '' ) !== 'some-unmapped-plugin',
+		'unmapped plugin must NOT have a mount entry'
+	);
+}
+
+// --- Test 5: agent stack is readonly -------------------------------------
+$agent_mounts = array_filter(
+	$recipe['mounts'],
+	fn( $m ) => ( $m['metadata']['kind'] ?? '' ) === 'agent-stack-plugin'
+);
+roadie_test_assert( count( $agent_mounts ) >= 3, 'agent stack must include at least 3 references; got ' . count( $agent_mounts ) );
+foreach ( $agent_mounts as $m ) {
+	roadie_test_assert( 'readonly' === $m['mode'], 'agent-stack mount must be readonly: ' . ( $m['metadata']['slug'] ?? '' ) );
+}
+
+// --- Test 6: editable_targets index ---------------------------------------
+roadie_test_assert(
+	isset( $recipe['editable_targets']['extrachill'] ),
+	'editable_targets must include theme slug'
+);
+roadie_test_assert(
+	isset( $recipe['editable_targets']['extrachill-community'] ),
+	'editable_targets must include community slug'
+);
+
+// --- Test 7: include_agent_stack=false drops the read-only branch --------
+$recipe2 = extrachill_roadie_build_recipe(
+	$context,
+	$repo_map,
+	array( 'include_agent_stack' => false )
+);
+foreach ( $recipe2['mounts'] as $m ) {
+	roadie_test_assert(
+		( $m['metadata']['kind'] ?? '' ) !== 'agent-stack-plugin',
+		'include_agent_stack=false should drop agent-stack mounts'
+	);
+}
+roadie_test_assert( empty( $recipe2['agent_stack_targets'] ), 'agent_stack_targets must be empty when disabled' );
+
+// --- Test 8: filter override on repo map adds a new mappable plugin -----
+roadie_test_reset_filters();
+add_filter(
+	'extrachill_roadie_repo_map',
+	function ( array $map ) {
+		$map['some-unmapped-plugin'] = array(
+			'repo'                        => 'Extra-Chill/some-unmapped-plugin',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'plugin',
+		);
+		return $map;
+	}
+);
+$updated_map = extrachill_roadie_default_repo_map();
+$recipe3     = extrachill_roadie_build_recipe( $context, $updated_map );
+$found       = false;
+foreach ( $recipe3['mounts'] as $m ) {
+	if ( ( $m['metadata']['slug'] ?? '' ) === 'some-unmapped-plugin' ) {
+		$found = true;
+		roadie_test_assert( 'readwrite' === $m['mode'], 'newly-mapped plugin should be readwrite' );
+		roadie_test_assert( 'Extra-Chill/some-unmapped-plugin' === $m['metadata']['repo'], 'newly-mapped repo' );
+	}
+}
+roadie_test_assert( $found, 'filter-added repo entry must produce a mount' );
+
+echo "contribute-code recipe-builder smoke passed.\n";

--- a/tests/contribute-code-subsite-context.php
+++ b/tests/contribute-code-subsite-context.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Smoke tests for extrachill_roadie_detect_subsite_context().
+ *
+ * Run with: php tests/contribute-code-subsite-context.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+
+// --- Test 1: main subsite, only community plugin active --------------------
+$GLOBALS['extrachill_roadie_test_state']['current_blog']   = 1;
+$GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array(
+	'extrachill-community/extrachill-community.php',
+	'breeze/breeze.php',                  // boilerplate, excluded
+	'extrachill-roadie/extrachill-roadie.php', // self, excluded
+);
+
+$context = extrachill_roadie_detect_subsite_context();
+
+roadie_test_assert( 1 === $context['blog_id'], 'blog_id should be 1.' );
+roadie_test_assert( 'extrachill' === $context['theme']['slug'], 'Theme slug should be extrachill.' );
+roadie_test_assert( '' === $context['theme']['parent_slug'], 'Parent slug should be empty for non-child theme.' );
+roadie_test_assert( 1 === count( $context['plugins'] ), 'Only extrachill-community should remain after exclusion; got ' . count( $context['plugins'] ) );
+roadie_test_assert( 'extrachill-community' === $context['plugins'][0]['slug'], 'Surviving plugin should be extrachill-community.' );
+roadie_test_assert(
+	str_ends_with( $context['plugins'][0]['path'], '/extrachill-community' ),
+	'Plugin path should resolve under WP_PLUGIN_DIR.'
+);
+
+// --- Test 2: community subsite, multiple uniquely-meaningful plugins ------
+$GLOBALS['extrachill_roadie_test_state']['current_blog']   = 2;
+$GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array(
+	'extrachill-community/extrachill-community.php',
+	'extrachill-artist-platform/extrachill-artist-platform.php',
+	'data-machine/data-machine.php', // agent stack, excluded
+);
+
+$context = extrachill_roadie_detect_subsite_context();
+roadie_test_assert( 2 === $context['blog_id'], 'blog_id should be 2.' );
+$slugs = array_map( fn( $p ) => $p['slug'], $context['plugins'] );
+sort( $slugs );
+roadie_test_assert(
+	$slugs === array( 'extrachill-artist-platform', 'extrachill-community' ),
+	'community subsite should expose artist-platform + community as editable. Got: ' . implode( ',', $slugs )
+);
+
+// --- Test 3: explicit exclusion override via filter -----------------------
+roadie_test_reset_filters();
+add_filter(
+	'extrachill_roadie_excluded_plugin_slugs',
+	function ( array $slugs ) {
+		// Drop extrachill-community from the exclusion list (it's not there
+		// by default but this exercises the filter wiring).
+		$slugs[] = 'extrachill-community';
+		return $slugs;
+	}
+);
+
+$GLOBALS['extrachill_roadie_test_state']['current_blog']   = 2;
+$GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array(
+	'extrachill-community/extrachill-community.php',
+	'extrachill-artist-platform/extrachill-artist-platform.php',
+);
+
+$context = extrachill_roadie_detect_subsite_context();
+$slugs   = array_map( fn( $p ) => $p['slug'], $context['plugins'] );
+roadie_test_assert(
+	$slugs === array( 'extrachill-artist-platform' ),
+	'Filtered exclusion should drop extrachill-community. Got: ' . implode( ',', $slugs )
+);
+
+// --- Test 4: single-file plugin slug extraction ---------------------------
+roadie_test_reset_filters();
+roadie_test_assert(
+	'single' === extrachill_roadie_plugin_file_to_slug( 'single.php' ),
+	'single-file slug should strip .php'
+);
+roadie_test_assert(
+	'multi' === extrachill_roadie_plugin_file_to_slug( 'multi/main.php' ),
+	'multi-file slug should take leading directory'
+);
+
+echo "contribute-code subsite-context smoke passed.\n";

--- a/tests/contribute-code-tool-registration.php
+++ b/tests/contribute-code-tool-registration.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Smoke test that the propose_code_change tool registers via
+ * `datamachine_tools` filter when the BaseTool class is available.
+ *
+ * Run with: php tests/contribute-code-tool-registration.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+
+// Provide a stub BaseTool so the tool class can be loaded.
+if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
+	eval(
+		'namespace DataMachine\\Engine\\AI\\Tools;
+		abstract class BaseTool {
+			protected function registerTool( string $toolName, $toolDefinition, array $modes = array(), array $meta = array() ): void {
+				$GLOBALS["extrachill_roadie_test_state"]["registered_tools"][ $toolName ] = array(
+					"definition" => $toolDefinition,
+					"modes"      => $modes,
+					"meta"       => $meta,
+				);
+			}
+			protected function buildErrorResponse( string $error, string $tool_name ): array {
+				return array( "success" => false, "error" => $error, "tool_name" => $tool_name );
+			}
+			protected function buildDiagnosticErrorResponse( string $error, string $type, string $tool_name, array $a = array(), array $b = array() ): array {
+				return array( "success" => false, "error" => $error, "type" => $type, "tool_name" => $tool_name );
+			}
+		}'
+	);
+}
+
+$GLOBALS['extrachill_roadie_test_state']['registered_tools'] = array();
+
+require_once dirname( __DIR__ ) . '/inc/tools/class-propose-code-change.php';
+$tool = new ECRoadie_ProposeCodeChange();
+
+roadie_test_assert(
+	isset( $GLOBALS['extrachill_roadie_test_state']['registered_tools']['propose_code_change'] ),
+	'propose_code_change must register via registerTool()'
+);
+
+$registration = $GLOBALS['extrachill_roadie_test_state']['registered_tools']['propose_code_change'];
+roadie_test_assert(
+	in_array( 'chat', $registration['modes'], true ),
+	'tool must register for chat mode'
+);
+roadie_test_assert(
+	'authenticated' === ( $registration['meta']['access_level'] ?? '' ),
+	'tool must require authenticated access_level'
+);
+
+$definition = $tool->getToolDefinition();
+roadie_test_assert( 'handle_tool_call' === $definition['method'], 'method must be handle_tool_call' );
+roadie_test_assert(
+	in_array( 'task_description', $definition['parameters']['required'] ?? array(), true ),
+	'task_description must be a required parameter'
+);
+roadie_test_assert(
+	isset( $definition['parameters']['properties']['task_description']['type'] )
+		&& 'string' === $definition['parameters']['properties']['task_description']['type'],
+	'task_description must be typed as string'
+);
+
+// --- Capability enforcement: contributor blocked -----------------------
+roadie_test_reset_filters();
+$GLOBALS['extrachill_roadie_test_state']['user_caps'] = array();
+$result_blocked = $tool->handle_tool_call( array( 'task_description' => 'add a typo fix' ) );
+roadie_test_assert(
+	false === $result_blocked['success'],
+	'capability check must block users without extrachill_propose_code'
+);
+roadie_test_assert(
+	false !== strpos( $result_blocked['error'] ?? '', 'permission' ),
+	'error message must mention permission'
+);
+
+// --- Empty task_description -------------------------------------------
+$GLOBALS['extrachill_roadie_test_state']['user_caps'][ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] = true;
+$result_empty = $tool->handle_tool_call( array( 'task_description' => '' ) );
+roadie_test_assert(
+	false === $result_empty['success'],
+	'empty task_description must fail'
+);
+roadie_test_assert(
+	false !== strpos( $result_empty['error'] ?? '', 'task_description' ),
+	'error must mention task_description'
+);
+
+// --- Missing wp_get_ability surfaces a useful error -------------------
+// wp_get_ability is intentionally undefined in this bootstrap.
+$result_no_ability = $tool->handle_tool_call( array( 'task_description' => 'do a thing' ) );
+roadie_test_assert(
+	false === $result_no_ability['success'],
+	'missing abilities API must surface an error'
+);
+
+echo "contribute-code tool-registration smoke passed.\n";

--- a/tests/contribute-code-tool-registration.php
+++ b/tests/contribute-code-tool-registration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Smoke test that the propose_code_change tool registers via
+ * Smoke test that propose_code_change AND apply_code_change register via the
  * `datamachine_tools` filter when the BaseTool class is available.
  *
  * Run with: php tests/contribute-code-tool-registration.php
@@ -10,7 +10,7 @@
 
 require_once __DIR__ . '/contribute-code-bootstrap.php';
 
-// Provide a stub BaseTool so the tool class can be loaded.
+// Provide a stub BaseTool so the tool classes can be loaded.
 if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
 	eval(
 		'namespace DataMachine\\Engine\\AI\\Tools;
@@ -35,63 +35,92 @@ if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
 $GLOBALS['extrachill_roadie_test_state']['registered_tools'] = array();
 
 require_once dirname( __DIR__ ) . '/inc/tools/class-propose-code-change.php';
-$tool = new ECRoadie_ProposeCodeChange();
+require_once dirname( __DIR__ ) . '/inc/tools/class-apply-code-change.php';
+$propose = new ECRoadie_ProposeCodeChange();
+$apply   = new ECRoadie_ApplyCodeChange();
 
+// --- Both tools register ------------------------------------------------
+foreach ( array( 'propose_code_change', 'apply_code_change' ) as $slug ) {
+	roadie_test_assert(
+		isset( $GLOBALS['extrachill_roadie_test_state']['registered_tools'][ $slug ] ),
+		$slug . ' must register via registerTool()'
+	);
+	$reg = $GLOBALS['extrachill_roadie_test_state']['registered_tools'][ $slug ];
+	roadie_test_assert(
+		in_array( 'chat', $reg['modes'], true ),
+		$slug . ' must register for chat mode'
+	);
+	roadie_test_assert(
+		'authenticated' === ( $reg['meta']['access_level'] ?? '' ),
+		$slug . ' must require authenticated access_level'
+	);
+}
+
+// --- propose_code_change definition ------------------------------------
+$propose_def = $propose->getToolDefinition();
+roadie_test_assert( 'handle_tool_call' === $propose_def['method'], 'propose method' );
 roadie_test_assert(
-	isset( $GLOBALS['extrachill_roadie_test_state']['registered_tools']['propose_code_change'] ),
-	'propose_code_change must register via registerTool()'
+	in_array( 'task_description', $propose_def['parameters']['required'] ?? array(), true ),
+	'propose: task_description required'
 );
 
-$registration = $GLOBALS['extrachill_roadie_test_state']['registered_tools']['propose_code_change'];
+// --- apply_code_change definition ---------------------------------------
+$apply_def = $apply->getToolDefinition();
+roadie_test_assert( 'handle_tool_call' === $apply_def['method'], 'apply method' );
 roadie_test_assert(
-	in_array( 'chat', $registration['modes'], true ),
-	'tool must register for chat mode'
-);
-roadie_test_assert(
-	'authenticated' === ( $registration['meta']['access_level'] ?? '' ),
-	'tool must require authenticated access_level'
+	in_array( 'artifact_id', $apply_def['parameters']['required'] ?? array(), true ),
+	'apply: artifact_id required'
 );
 
-$definition = $tool->getToolDefinition();
-roadie_test_assert( 'handle_tool_call' === $definition['method'], 'method must be handle_tool_call' );
-roadie_test_assert(
-	in_array( 'task_description', $definition['parameters']['required'] ?? array(), true ),
-	'task_description must be a required parameter'
-);
-roadie_test_assert(
-	isset( $definition['parameters']['properties']['task_description']['type'] )
-		&& 'string' === $definition['parameters']['properties']['task_description']['type'],
-	'task_description must be typed as string'
-);
-
-// --- Capability enforcement: contributor blocked -----------------------
+// --- Capability enforcement: contributor blocked on propose ------------
 roadie_test_reset_filters();
 $GLOBALS['extrachill_roadie_test_state']['user_caps'] = array();
-$result_blocked = $tool->handle_tool_call( array( 'task_description' => 'add a typo fix' ) );
+$result_blocked = $propose->handle_tool_call( array( 'task_description' => 'add a typo fix' ) );
 roadie_test_assert(
 	false === $result_blocked['success'],
-	'capability check must block users without extrachill_propose_code'
+	'propose capability check must block users without extrachill_propose_code'
 );
 roadie_test_assert(
 	false !== strpos( $result_blocked['error'] ?? '', 'permission' ),
-	'error message must mention permission'
+	'propose error must mention permission'
 );
 
-// --- Empty task_description -------------------------------------------
+// --- Capability enforcement: contributor blocked on apply ---------------
+$result_apply_blocked = $apply->handle_tool_call( array( 'artifact_id' => 'artifact-bundle-foo' ) );
+roadie_test_assert(
+	false === $result_apply_blocked['success'],
+	'apply capability check must block users without extrachill_propose_code'
+);
+
+// --- Empty inputs ------------------------------------------------------
 $GLOBALS['extrachill_roadie_test_state']['user_caps'][ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] = true;
-$result_empty = $tool->handle_tool_call( array( 'task_description' => '' ) );
+
+$result_empty = $propose->handle_tool_call( array( 'task_description' => '' ) );
 roadie_test_assert(
 	false === $result_empty['success'],
-	'empty task_description must fail'
-);
-roadie_test_assert(
-	false !== strpos( $result_empty['error'] ?? '', 'task_description' ),
-	'error must mention task_description'
+	'empty propose task_description must fail'
 );
 
-// --- Missing wp_get_ability surfaces a useful error -------------------
-// wp_get_ability is intentionally undefined in this bootstrap.
-$result_no_ability = $tool->handle_tool_call( array( 'task_description' => 'do a thing' ) );
+$result_empty_id = $apply->handle_tool_call( array( 'artifact_id' => '' ) );
+roadie_test_assert(
+	false === $result_empty_id['success'],
+	'empty apply artifact_id must fail'
+);
+
+// --- Apply: missing GITHUB_TOKEN fails with clear error -----------------
+putenv( 'GITHUB_TOKEN=' );
+$result_no_token = $apply->handle_tool_call( array( 'artifact_id' => 'artifact-bundle-foo' ) );
+roadie_test_assert(
+	false === $result_no_token['success'],
+	'apply must fail when GITHUB_TOKEN is unset'
+);
+roadie_test_assert(
+	false !== strpos( $result_no_token['error'] ?? '', 'GITHUB_TOKEN' ),
+	'apply error must mention GITHUB_TOKEN'
+);
+
+// --- Propose: missing wp_get_ability surfaces a useful error -----------
+$result_no_ability = $propose->handle_tool_call( array( 'task_description' => 'do a thing' ) );
 roadie_test_assert(
 	false === $result_no_ability['success'],
 	'missing abilities API must surface an error'


### PR DESCRIPTION
Implements the sandbox-backed contribute-code flow described in #11. Team members chatting with Roadie on any subsite can describe a code change, and Roadie dispatches a WP Codebox Playground sandbox that implements the change and opens a PR for human review.

## Summary

- **Subsite context detection** — pure function that resolves the active theme + subsite-specific plugins, excluding network-active platform boilerplate.
- **Filterable slug -> repo map** — consumer-owned (per chubes4/wp-codebox#82) covering EC themes/plugins + the read-only agent stack.
- **Recipe builder** — emits the `mounts` array for `wp-codebox/run-agent-task` with per-mount `metadata.repo`, `default_branch`, and `repo_root_relative_to_mount`; theme + EC plugins are `readwrite`, agent stack is `readonly`.
- **`extrachill_propose_code` capability** — granted to administrators and editors by default; role list and per-user grant are both filterable.
- **`GITHUB_TOKEN` plumbing** — only the env var name is passed in `secret_env`; the value lives in the WordPress PHP process environment, per the WP Codebox `secret_env` contract. Env var name is overridable via the `extrachill_roadie_github_token_env` network option or filter.
- **`propose_code_change` chat tool** — capability check, context detection, recipe build, token-presence check, ability invocation with `preview_hold_seconds=900`, and a chat-friendly response shape (summary, changed files, preview URL, PR URL, artifact metadata).
- **Docs** — `docs/contribute-code.md` covers operator setup (token, caps, repo map overrides) and the manual smoke-test command.

## Acceptance (from #11)

- [x] Subsite context detection function with tests.
- [x] Recipe generation integrated with wp-codebox (mounts array shape matches the schema shipped in chubes4/wp-codebox#82).
- [x] Roadie tool registered for sandbox invocation (`propose_code_change` via `datamachine_tools`).
- [x] `GITHUB_TOKEN` plumbed via `--secret-env` (platform bot path; user-linked path explicitly out of scope for v1, documented as a future stretch).
- [x] Artifact review rendering in chat (summary + PR URL + changed files + preview URL).
- [x] Capability check for propose-code on the tool (`extrachill_propose_code`).
- [ ] End-to-end smoke: deferred to manual smoke test (documented in `docs/contribute-code.md`). The live wp-codebox CLI + a real `GITHUB_TOKEN` are required to exercise it; the manual command is checked in.

## Tests

Run from the plugin root:

\`\`\`bash
php tests/contribute-code-subsite-context.php
php tests/contribute-code-recipe-builder.php
php tests/contribute-code-capabilities.php
php tests/contribute-code-tool-registration.php
php tests/frontend-chat-branding-smoke.php   # existing test, still green
\`\`\`

Coverage:

- `subsite-context`: exclusion of platform boilerplate, multi-subsite shape, filter override on exclusion list, single-file plugin slug extraction.
- `recipe-builder`: theme + plugin mounts (readwrite), agent stack mounts (readonly), unmapped plugin tracking, `include_agent_stack=false`, filter override on the repo map.
- `capabilities`: role-based grant (admin/editor receive, contributor doesn't), filter expansion (author granted via filter), env var name resolution (default, site option, filter), token presence check (empty vs non-empty).
- `tool-registration`: tool registers via `datamachine_tools`, declares chat mode + `authenticated` access_level, requires `task_description`, blocks users without the cap, fails on empty input, surfaces a clear error when the abilities API is unavailable.

## Manual smoke test

Documented in `docs/contribute-code.md`. Prereqs:

- \`wp-codebox\` active on the network.
- \`GITHUB_TOKEN\` (or the configured env var) exported in the WordPress PHP process (e.g. via \`putenv()\` in \`wp-config.php\`).
- Logged-in user with \`extrachill_propose_code\`.

\`\`\`bash
wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com eval '
\$tool = new ECRoadie_ProposeCodeChange();
\$result = \$tool->handle_tool_call( array(
    "task_description" => "Add a comment with the word ROADIE_SMOKE_TEST to the top of the main plugin file of extrachill-community."
) );
echo wp_json_encode( \$result, JSON_PRETTY_PRINT );'
\`\`\`

Expected: \`success === true\`, \`data.pr_url\` points at a new PR in \`Extra-Chill/extrachill-community\`, \`data.preview_url\` opens for ~15 minutes after dispatch.

## Out of scope (per #11)

- Homeboy authoring-side integration (DMC Code's existing GitHub tooling owns the PR open path).
- Cross-site DMC coordination (the sandbox is self-contained).
- Per-user GitHub OAuth in \`extrachill-users\` — documented as a future stretch; the same \`secret_env\` plumbing supports it when the option arrives.

## Notes for the reviewer

- File layout: contribute-code pieces live in \`inc/contribute-code/\` so they're easy to find as a unit; the tool itself is in \`inc/tools/class-propose-code-change.php\` next to the existing platform tools.
- The agent stack list (\`agents-api\`, \`data-machine\`, \`data-machine-code\`, AI providers) is mounted readonly so the sandboxed agent can grep them while implementing changes — they are NOT editable.
- Conventional commits used throughout; CHANGELOG.md is intentionally untouched (homeboy owns release notes).