### PR TITLE
feat(permissions): wire events-admin cap + switch roadie bridge to cap check

### DIFF
--- a/inc/permissions.php
+++ b/inc/permissions.php
@@ -56,9 +56,18 @@ function extrachill_roadie_allowed_redirect_uris(): array {
 /**
  * Grant team members access to the roadie agent.
  *
- * Hooks `datamachine_can_access_agent` to check EC team membership
- * when the agent in question is the roadie agent. This bridges
- * EC's custom team meta to DM's permission system.
+ * Hooks `datamachine_can_access_agent` (a generic Data Machine
+ * filter) and elevates EC team members to roadie-agent access. This
+ * is the platform-specific policy layer: Data Machine knows nothing
+ * about Extra Chill team membership; extrachill-roadie is the
+ * one-and-only place where EC-specific knowledge meets DM's generic
+ * permission surface.
+ *
+ * Team membership is sourced from the `access_studio` capability —
+ * granted by the `extra_chill_team` role (extrachill-users#45) on
+ * every site in the network. We use `user_can()` directly rather
+ * than `ec_is_team_member()` so this function stays a thin policy
+ * shim that can be reasoned about by reading just this file.
  *
  * @since 0.3.0
  *
@@ -82,14 +91,51 @@ function extrachill_roadie_team_access_bridge( bool $can_access, int $agent_id, 
 		return $can_access;
 	}
 
-	// Use the existing Extra Chill team access bridge as the source of truth.
-	if ( function_exists( 'ec_is_team_member' ) && ec_is_team_member( $user_id ) ) {
+	// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom cap granted by the extra_chill_team role (extrachill-users#45).
+	if ( user_can( $user_id, 'access_roadie' ) ) {
 		return true;
 	}
 
 	return $can_access;
 }
 add_filter( 'datamachine_can_access_agent', 'extrachill_roadie_team_access_bridge', 10, 4 );
+
+/**
+ * Map Data Machine Events' write capability to the EC team cap.
+ *
+ * data-machine-events defaults its write gate to `edit_others_posts`
+ * (administrators + editors only). On Extra Chill, the team role
+ * (`extra_chill_team`) is the natural trust pool for events admin
+ * because team contributors are journalists who need to fix venue
+ * data, merge duplicates, and run geocoding sweeps without being
+ * site administrators. The role grants `access_events_admin`, which
+ * we wire up as DME's write cap on every EC subsite.
+ *
+ * Pure policy bridge — DME knows nothing about EC; EC's integration
+ * layer (this plugin) overrides DME's default via its filter API.
+ *
+ * @since 0.7.0
+ * @return string
+ */
+function extrachill_roadie_events_write_capability(): string {
+	return 'access_events_admin';
+}
+add_filter( 'datamachine_events_write_capability', 'extrachill_roadie_events_write_capability' );
+
+/**
+ * Same shape for DME's diagnostic read gate.
+ *
+ * Currently the only read ability hooked through DME's filter is
+ * unused by default, but providing the bridge here keeps the
+ * mapping consistent should a read-gated ability be added later.
+ *
+ * @since 0.7.0
+ * @return string
+ */
+function extrachill_roadie_events_read_capability(): string {
+	return 'access_events_admin';
+}
+add_filter( 'datamachine_events_read_capability', 'extrachill_roadie_events_read_capability' );
 
 /**
  * Get the roadie agent ID from the frontend chat config.


### PR DESCRIPTION
Companion to [Extra-Chill/data-machine-events#295](https://github.com/Extra-Chill/data-machine-events/pull/295) (layer-purity cleanup that introduced filterable capability hooks for DME's write/read gates).

## Two changes

### 1. Wire \`access_events_admin\` into DME's filter hooks

\`data-machine-events\` defaults its write capability to \`edit_others_posts\` (administrators + editors). Extra Chill team contributors are journalists who need to fix venue data, merge duplicates, and run geocoding sweeps via Roadie chat tools — they need write access without being site editors.

This PR hooks DME's new \`datamachine_events_write_capability\` and \`datamachine_events_read_capability\` filters and returns \`access_events_admin\` — the custom capability granted by the \`extra_chill_team\` role introduced in extrachill-users#45.

### 2. Switch the Roadie agent-access bridge from \`ec_is_team_member()\` to a direct cap check

\`extrachill_roadie_team_access_bridge\` previously called \`ec_is_team_member()\`. After extrachill-users#45 shipped, the team role grants \`access_roadie\` directly — so the cleaner expression is:

\`\`\`php
if ( user_can( \$user_id, 'access_roadie' ) ) {
    return true;
}
\`\`\`

Identical behavior, reads cleaner — the function is now a thin policy bridge that names exactly the capability it gates.

## Verification

Smoke-tested both branches against live production data:

| User | \`is_team_member()\` | \`user_can('access_roadie')\` |
|---|---|---|
| chubes | YES | YES |
| qrisg | YES | YES |
| indigxld | YES | YES |
| sarahbentley | no | no |

All four match. Behavior preserved.

## Coordinated deploy

This PR depends on DME#295 being deployed first — without the filter hooks, the \`add_filter()\` calls are no-ops and DME's write gate falls back to its default of \`edit_others_posts\` (so EC team contributors lose write access until DME ships). Safe to merge here at any point but deploy DME first.

## Refs

- Refs Extra-Chill/data-machine-events#294 (the layer-purity issue) + PR #295 (the fix)
- Refs Extra-Chill/extrachill-users#45 (introduces \`access_events_admin\` / \`access_roadie\` caps via the team role)