### PR TITLE
fix(token-bridge): bridge FAB chrome to --accent for visibility

### DIFF
--- a/assets/css/token-bridge.css
+++ b/assets/css/token-bridge.css
@@ -23,9 +23,11 @@
 
 :root {
 	/* ── FAB chrome ─────────────────────────────────────── */
-	--frontend-agent-chat-fab-bg: var(--header-background, #1a1a2e);
-	--frontend-agent-chat-fab-color: var(--header-text-color, #fff);
-	--frontend-agent-chat-fab-border-color: var(--border-color, transparent);
+	/* Bridge to the EC brand action color (--accent) so the FAB reads as
+	 * "click me" instead of inheriting header chrome. See issue #15. */
+	--frontend-agent-chat-fab-bg: var(--accent, #53940b);
+	--frontend-agent-chat-fab-color: var(--button-text-color, #fff);
+	--frontend-agent-chat-fab-border-color: var(--accent-hover, transparent);
 	--frontend-agent-chat-fab-font-size: var(--font-size-base, 15px);
 	--frontend-agent-chat-fab-badge-bg: var(--error-color, #d63638);
 


### PR DESCRIPTION
## Summary

- Closes #15
- Re-bridges the Roadie FAB from `--header-background` (pure black) to `--accent` (EC brand green `#53940b`) so it reads as a "click me" action and stops blending into dark surfaces.
- Pairs `--frontend-agent-chat-fab-border-color` with `--accent-hover` for a coherent edge.
- Touches only `assets/css/token-bridge.css` — no FAC plugin changes, no new tokens, dark-mode safe.

## Why

@qrisg flagged the FAB doesn't stand out enough. The bridge was inheriting header chrome, which is visually quiet against the white EC body and invisible against the header itself. `--accent` is already the theme's universal action color (buttons, focus rings, links), so this is the most brand-correct loud color we have without adding new design system surface.

## Diff

```css
- --frontend-agent-chat-fab-bg: var(--header-background, #1a1a2e);
- --frontend-agent-chat-fab-color: var(--header-text-color, #fff);
- --frontend-agent-chat-fab-border-color: var(--border-color, transparent);
+ --frontend-agent-chat-fab-bg: var(--accent, #53940b);
+ --frontend-agent-chat-fab-color: var(--button-text-color, #fff);
+ --frontend-agent-chat-fab-border-color: var(--accent-hover, transparent);
```

## Follow-ups (if @qrisg wants more pop)

- Lobster on FAB label via `--font-family-brand`
- Friendlier badge using `--accent-3` cyan instead of `--error-color`

mention @qrisg when ready for review