### PR TITLE
feat(tools): file_feature_request chat tool for filing GitHub issues from Roadie

### DIFF
--- a/inc/contribute-code/recipe-builder.php
+++ b/inc/contribute-code/recipe-builder.php
@@ -178,6 +178,13 @@ function extrachill_roadie_build_recipe( array $context, array $repo_map, array 
 		if ( 'agent-stack-plugin' === $kind ) {
 			continue;
 		}
+		// Platform-wide plugins are issue-trackable + code-trackable, but
+		// not editable from a subsite-context recipe. The subsite-context
+		// detector already excludes them from $context['plugins'], so this
+		// guard is belt-and-suspenders against future exclusion-list drift.
+		if ( 'platform-plugin' === $kind ) {
+			continue;
+		}
 
 		$target = $wp_content_target . '/plugins/' . $slug;
 		$mount  = $build_mount( $kind, $slug, $entry, $target );

--- a/inc/contribute-code/repo-map.php
+++ b/inc/contribute-code/repo-map.php
@@ -27,7 +27,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Slug categories are tracked via `kind`:
  *   - `theme`              — wp-content/themes/<slug>/
- *   - `plugin`             — wp-content/plugins/<slug>/
+ *   - `plugin`             — wp-content/plugins/<slug>/, subsite-specific
+ *   - `platform-plugin`    — wp-content/plugins/<slug>/, network-wide platform
+ *                             boilerplate. Excluded from subsite-context detection
+ *                             (so it doesn't mount as an editable surface when a
+ *                             contributor is on a subsite), but available in the
+ *                             registry for issue-tracking, cross-repo references,
+ *                             and explicit-target code changes.
  *   - `agent-stack-plugin` — read-only references the sandboxed agent needs
  *
  * @since 0.7.0
@@ -97,6 +103,86 @@ function extrachill_roadie_default_repo_map(): array {
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
+		),
+
+		// Network-wide platform plugins. Not auto-mounted as editable surfaces
+		// when a contributor is chatting from a subsite (the subsite-context
+		// detector deliberately excludes them — they're platform boilerplate
+		// from the subsite's POV), but they ARE legitimately issue-trackable
+		// and code-change-trackable. Listing them here keeps the registry as
+		// the single allowlist consulted by both `file_feature_request` and
+		// future explicit-repo override flows.
+		'extrachill-roadie' => array(
+			'repo'                        => 'Extra-Chill/extrachill-roadie',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-users' => array(
+			'repo'                        => 'Extra-Chill/extrachill-users',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-multisite' => array(
+			'repo'                        => 'Extra-Chill/extrachill-multisite',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-api' => array(
+			'repo'                        => 'Extra-Chill/extrachill-api',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-admin-tools' => array(
+			'repo'                        => 'Extra-Chill/extrachill-admin-tools',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-newsletter' => array(
+			'repo'                        => 'Extra-Chill/extrachill-newsletter',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-search' => array(
+			'repo'                        => 'Extra-Chill/extrachill-search',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-seo' => array(
+			'repo'                        => 'Extra-Chill/extrachill-seo',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-analytics' => array(
+			'repo'                        => 'Extra-Chill/extrachill-analytics',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-cli' => array(
+			'repo'                        => 'Extra-Chill/extrachill-cli',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-tokens' => array(
+			'repo'                        => 'Extra-Chill/extrachill-tokens',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
+		),
+		'extrachill-components' => array(
+			'repo'                        => 'Extra-Chill/extrachill-components',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'platform-plugin',
 		),
 
 		// Read-only agent stack (mounted as references so the sandboxed agent

--- a/inc/contribute-code/subsite-context.php
+++ b/inc/contribute-code/subsite-context.php
@@ -44,6 +44,8 @@ function extrachill_roadie_default_excluded_plugin_slugs(): array {
 		'extrachill-seo',
 		'extrachill-analytics',
 		'extrachill-cli',
+		'extrachill-tokens',
+		'extrachill-components',
 		'chubes-gallery-lightbox',
 		'redis-cache',
 		'easy-wp-smtp',

--- a/inc/tools/class-file-feature-request.php
+++ b/inc/tools/class-file-feature-request.php
@@ -1,0 +1,657 @@
+<?php
+/**
+ * File Feature Request Tool
+ *
+ * Chat tool that lets team members file GitHub issues against the appropriate
+ * Extra Chill repo from inside a Roadie chat. Companion to propose_code_change
+ * (PR #13): different intent, lighter touch.
+ *
+ * Use cases this tool covers:
+ *   - "I have an idea for the FAB color" -> file_issue on extrachill-roadie.
+ *   - "Did we already file something about this?" -> list_recent_issues.
+ *   - "Add a note to that existing issue" -> comment_on_issue.
+ *
+ * Repo inference reuses `inc/contribute-code/repo-map.php` from PR #13 so the
+ * registry stays single-source. Capability gate reuses `extrachill_propose_code`
+ * for the same reason — every team member who can propose code should also be
+ * able to file ideas, and we don't want a parallel cap to manage.
+ *
+ * All three actions delegate to existing Data Machine abilities:
+ *   - file_issue        -> datamachine/create-github-issue
+ *   - list_recent_issues -> datamachine/list-github-issues
+ *   - comment_on_issue  -> datamachine/comment-github-issue
+ *
+ * The tool's job is the chat-facing contract (capability check, repo allowlist
+ * against the EC repo map, auto-labels, author attribution) — not the GitHub
+ * API itself.
+ *
+ * @package ExtraChillRoadie\Tools
+ * @since 0.8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class ECRoadie_FileFeatureRequest extends BaseTool {
+
+	protected string $tool_slug = 'file_feature_request';
+
+	/**
+	 * Default labels applied to every Roadie-filed issue, before any
+	 * action-specific labels the caller passes in.
+	 *
+	 * Override via the `extrachill_roadie_feature_request_default_labels`
+	 * filter.
+	 *
+	 * @var string[]
+	 */
+	protected const DEFAULT_LABELS = array( 'roadie-submitted', 'feature-request' );
+
+	public function __construct() {
+		$this->registerTool(
+			$this->tool_slug,
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'access_level' => 'authenticated' )
+		);
+	}
+
+	/**
+	 * Tool definition.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'When the user describes an idea, feature request, or bug observation that should be tracked (rather than implemented right now), use this tool to file or look up GitHub issues against the appropriate Extra Chill repo. Three actions are supported: action="file_issue" creates a new issue (requires repo, title, body); action="list_recent_issues" finds existing open issues to dedupe against (requires repo, optional labels/state); action="comment_on_issue" adds a comment to an existing issue (requires repo, issue_number, body). Before filing new issues, prefer calling list_recent_issues first with a few keywords from the proposed title to surface duplicates and ask the user whether to comment on an existing thread instead. Use propose_code_change instead when the user wants the change implemented, not just tracked.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'action', 'repo' ),
+				'properties' => array(
+					'action'       => array(
+						'type'        => 'string',
+						'enum'        => array( 'file_issue', 'list_recent_issues', 'comment_on_issue' ),
+						'description' => 'Which sub-action to run.',
+					),
+					'repo'         => array(
+						'type'        => 'string',
+						'description' => 'GitHub repo in owner/name form (e.g. Extra-Chill/extrachill-roadie). Must be present in the slug-to-repo registry; cross-org repos are rejected.',
+					),
+					'title'        => array(
+						'type'        => 'string',
+						'description' => 'Issue title. Required for action=file_issue. A concise, action-oriented summary.',
+					),
+					'body'         => array(
+						'type'        => 'string',
+						'description' => 'Issue or comment body in GitHub Markdown. Required for file_issue and comment_on_issue. Include enough context that the issue is actionable without the original chat.',
+					),
+					'issue_number' => array(
+						'type'        => 'integer',
+						'description' => 'Existing issue number. Required for action=comment_on_issue.',
+					),
+					'labels'       => array(
+						'type'        => 'array',
+						'items'       => array( 'type' => 'string' ),
+						'description' => 'Optional extra labels to attach to a new issue (only used with file_issue). The default labels "roadie-submitted" and "feature-request" are always applied.',
+					),
+					'state'        => array(
+						'type'        => 'string',
+						'enum'        => array( 'open', 'closed', 'all' ),
+						'description' => 'Issue state for list_recent_issues. Defaults to "open".',
+					),
+					'keywords'     => array(
+						'type'        => 'string',
+						'description' => 'Free-form keywords for the agent loop to use when judging dedupe overlap with list_recent_issues results. Echoed back in the response to keep the model anchored on the original phrasing; not passed to the GitHub API.',
+					),
+					'per_page'     => array(
+						'type'        => 'integer',
+						'description' => 'How many recent issues to fetch with list_recent_issues. Defaults to 20, max 100.',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tool callback.
+	 *
+	 * @param array<string,mixed> $parameters Tool parameters.
+	 * @param array<string,mixed> $tool_def   Resolved tool definition (unused).
+	 * @return array<string,mixed>
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		unset( $tool_def );
+
+		// 1. Capability check — reuse the propose-code cap. Every team member
+		// who can propose a code change should also be able to file an idea;
+		// keeping these on one cap avoids a parallel grant flow for operators.
+		$cap = defined( 'EXTRACHILL_ROADIE_PROPOSE_CODE_CAP' ) ? EXTRACHILL_ROADIE_PROPOSE_CODE_CAP : 'extrachill_propose_code';
+		if ( ! current_user_can( $cap ) ) {
+			return $this->buildErrorResponse(
+				sprintf(
+					'You do not have permission to file feature requests. Ask an administrator to grant the "%s" capability.',
+					$cap
+				),
+				$this->tool_slug
+			);
+		}
+
+		// 2. Validate action.
+		$action = trim( (string) ( $parameters['action'] ?? '' ) );
+		if ( ! in_array( $action, array( 'file_issue', 'list_recent_issues', 'comment_on_issue' ), true ) ) {
+			return $this->buildErrorResponse(
+				'action is required and must be one of: file_issue, list_recent_issues, comment_on_issue.',
+				$this->tool_slug
+			);
+		}
+
+		// 3. Validate repo against the slug-to-repo registry.
+		$repo  = trim( (string) ( $parameters['repo'] ?? '' ) );
+		$check = $this->validate_repo( $repo );
+		if ( true !== $check ) {
+			return $check;
+		}
+
+		// 4. Verify abilities API + the specific ability we need.
+		$ability_check = $this->require_ability( $this->ability_for_action( $action ) );
+		if ( true !== $ability_check ) {
+			return $ability_check;
+		}
+
+		switch ( $action ) {
+			case 'file_issue':
+				return $this->handle_file_issue( $parameters, $repo );
+			case 'list_recent_issues':
+				return $this->handle_list_recent_issues( $parameters, $repo );
+			case 'comment_on_issue':
+				return $this->handle_comment_on_issue( $parameters, $repo );
+		}
+
+		// Unreachable — action is validated above. Defensive default.
+		return $this->buildErrorResponse(
+			'Unhandled action: ' . $action,
+			$this->tool_slug
+		);
+	}
+
+	/**
+	 * Map an action to its backing Data Machine ability name.
+	 *
+	 * @param string $action Action slug.
+	 * @return string
+	 */
+	protected function ability_for_action( string $action ): string {
+		switch ( $action ) {
+			case 'file_issue':
+				return 'datamachine/create-github-issue';
+			case 'list_recent_issues':
+				return 'datamachine/list-github-issues';
+			case 'comment_on_issue':
+				return 'datamachine/comment-github-issue';
+		}
+		return '';
+	}
+
+	/**
+	 * Validate the requested repo against the EC slug-to-repo registry.
+	 *
+	 * Cross-org repos and arbitrary repos not in the registry are rejected
+	 * here so the GitHub PAT can never be turned into a write surface against
+	 * repos the operator never intended to expose.
+	 *
+	 * @param string $repo Repo in owner/name form.
+	 * @return true|array True on success, error response array on failure.
+	 */
+	protected function validate_repo( string $repo ) {
+		if ( '' === $repo ) {
+			return $this->buildErrorResponse(
+				'repo is required in owner/name form (e.g. Extra-Chill/extrachill-roadie).',
+				$this->tool_slug
+			);
+		}
+
+		if ( ! function_exists( 'extrachill_roadie_default_repo_map' ) ) {
+			return $this->buildErrorResponse(
+				'The slug-to-repo registry is not loaded. Ensure inc/contribute-code/repo-map.php is required.',
+				$this->tool_slug
+			);
+		}
+
+		$allowed_repos = $this->allowed_repos();
+		if ( ! in_array( $repo, $allowed_repos, true ) ) {
+			return $this->buildErrorResponse(
+				sprintf(
+					'Repo "%s" is not in the Extra Chill repo registry. Allowed repos: %s. To add a new repo, extend the `extrachill_roadie_repo_map` filter.',
+					$repo,
+					implode( ', ', $allowed_repos )
+				),
+				$this->tool_slug
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Flat list of allowed `owner/name` repos derived from the registry.
+	 *
+	 * Includes agent-stack entries because they are still legitimately
+	 * issue-trackable; the registry is the operator's allowlist, not a
+	 * write-vs-read distinction.
+	 *
+	 * @return string[]
+	 */
+	protected function allowed_repos(): array {
+		$repos = array();
+		foreach ( extrachill_roadie_default_repo_map() as $entry ) {
+			$repo = (string) ( $entry['repo'] ?? '' );
+			if ( '' !== $repo ) {
+				$repos[] = $repo;
+			}
+		}
+		/**
+		 * Filter the flat allowlist of `owner/name` repos accepted by the
+		 * file_feature_request tool. Defaults to every repo in the EC
+		 * slug-to-repo registry.
+		 *
+		 * @since 0.8.0
+		 *
+		 * @param string[] $repos Allowed repos.
+		 */
+		$repos = (array) apply_filters( 'extrachill_roadie_feature_request_allowed_repos', array_values( array_unique( $repos ) ) );
+
+		return array_values( array_map( 'strval', $repos ) );
+	}
+
+	/**
+	 * Confirm an ability is loaded and callable.
+	 *
+	 * @param string $ability_name Fully qualified ability name.
+	 * @return true|array True on success, error response on failure.
+	 */
+	protected function require_ability( string $ability_name ) {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return $this->buildErrorResponse(
+				'The WordPress Abilities API is not available on this site.',
+				$this->tool_slug
+			);
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability ) {
+			return $this->buildErrorResponse(
+				sprintf(
+					'The "%s" ability is not registered. Install/activate the Data Machine plugin that provides it.',
+					$ability_name
+				),
+				$this->tool_slug
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * file_issue handler.
+	 *
+	 * @param array<string,mixed> $parameters Tool parameters.
+	 * @param string              $repo       Validated repo.
+	 * @return array<string,mixed>
+	 */
+	protected function handle_file_issue( array $parameters, string $repo ): array {
+		$title = trim( (string) ( $parameters['title'] ?? '' ) );
+		$body  = (string) ( $parameters['body'] ?? '' );
+
+		if ( '' === $title ) {
+			return $this->buildErrorResponse(
+				'title is required for action=file_issue.',
+				$this->tool_slug
+			);
+		}
+
+		if ( '' === trim( $body ) ) {
+			return $this->buildErrorResponse(
+				'body is required for action=file_issue. Include enough context that the issue is actionable without the original chat.',
+				$this->tool_slug
+			);
+		}
+
+		// Merge caller-supplied labels with the defaults. Defaults always win
+		// on dedupe so we never lose `roadie-submitted` / `feature-request`.
+		$caller_labels  = array_values(
+			array_filter(
+				array_map( 'strval', (array) ( $parameters['labels'] ?? array() ) ),
+				static function ( string $label ): bool {
+					return '' !== trim( $label );
+				}
+			)
+		);
+		$default_labels = (array) apply_filters(
+			'extrachill_roadie_feature_request_default_labels',
+			self::DEFAULT_LABELS
+		);
+		$labels         = array_values(
+			array_unique(
+				array_merge(
+					array_map( 'strval', $default_labels ),
+					$caller_labels
+				)
+			)
+		);
+
+		$augmented_body = $this->augment_body_with_attribution( $body );
+
+		$input = array(
+			'repo'   => $repo,
+			'title'  => $title,
+			'body'   => $augmented_body,
+			'labels' => $labels,
+		);
+
+		/**
+		 * Filter the input passed to `datamachine/create-github-issue`.
+		 *
+		 * @since 0.8.0
+		 *
+		 * @param array  $input      Ability input.
+		 * @param array  $parameters Original tool parameters.
+		 * @param string $repo       Validated repo.
+		 */
+		$input = (array) apply_filters( 'extrachill_roadie_file_issue_input', $input, $parameters, $repo );
+
+		$result = wp_get_ability( 'datamachine/create-github-issue' )->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				'GitHub issue creation failed: ' . $result->get_error_message(),
+				$this->tool_slug
+			);
+		}
+
+		if ( ! is_array( $result ) ) {
+			return $this->buildErrorResponse(
+				'Unexpected response shape from datamachine/create-github-issue.',
+				$this->tool_slug
+			);
+		}
+
+		$issue_url    = (string) ( $result['html_url'] ?? $result['url'] ?? '' );
+		$issue_number = isset( $result['number'] ) ? (int) $result['number'] : 0;
+
+		return array(
+			'success'   => true,
+			'tool_name' => $this->tool_slug,
+			'data'      => array(
+				'action'       => 'file_issue',
+				'repo'         => $repo,
+				'issue_number' => $issue_number,
+				'issue_url'    => $issue_url,
+				'labels'       => $labels,
+				'next_step'    => 'If this issue describes a code change rather than just an idea to track, offer to call propose_code_change next so a sandbox can implement it.',
+				'raw'          => $result,
+			),
+		);
+	}
+
+	/**
+	 * list_recent_issues handler.
+	 *
+	 * @param array<string,mixed> $parameters Tool parameters.
+	 * @param string              $repo       Validated repo.
+	 * @return array<string,mixed>
+	 */
+	protected function handle_list_recent_issues( array $parameters, string $repo ): array {
+		$state    = (string) ( $parameters['state'] ?? 'open' );
+		if ( ! in_array( $state, array( 'open', 'closed', 'all' ), true ) ) {
+			$state = 'open';
+		}
+
+		$per_page = (int) ( $parameters['per_page'] ?? 20 );
+		$per_page = max( 1, min( 100, $per_page ) );
+
+		$input = array(
+			'repo'     => $repo,
+			'state'    => $state,
+			'per_page' => $per_page,
+		);
+
+		/**
+		 * Filter the input passed to `datamachine/list-github-issues`.
+		 *
+		 * @since 0.8.0
+		 *
+		 * @param array  $input      Ability input.
+		 * @param array  $parameters Original tool parameters.
+		 * @param string $repo       Validated repo.
+		 */
+		$input = (array) apply_filters( 'extrachill_roadie_list_issues_input', $input, $parameters, $repo );
+
+		$result = wp_get_ability( 'datamachine/list-github-issues' )->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				'GitHub issue list failed: ' . $result->get_error_message(),
+				$this->tool_slug
+			);
+		}
+
+		// Normalize the issue list down to the fields the model needs for
+		// dedupe judgment without dragging the entire GitHub API payload
+		// through the chat context window.
+		$issues_raw = is_array( $result ) ? $result : array();
+		$issues     = array();
+		foreach ( $issues_raw as $issue ) {
+			if ( ! is_array( $issue ) ) {
+				continue;
+			}
+			// GitHub returns PRs in the issues endpoint too; PRs carry
+			// `pull_request`. Skip them so dedupe only compares issue-to-issue.
+			if ( isset( $issue['pull_request'] ) ) {
+				continue;
+			}
+			$issues[] = array(
+				'number'     => (int) ( $issue['number'] ?? 0 ),
+				'title'      => (string) ( $issue['title'] ?? '' ),
+				'state'      => (string) ( $issue['state'] ?? '' ),
+				'url'        => (string) ( $issue['html_url'] ?? '' ),
+				'labels'     => $this->normalize_labels( $issue['labels'] ?? array() ),
+				'updated_at' => (string) ( $issue['updated_at'] ?? '' ),
+			);
+		}
+
+		$keywords = trim( (string) ( $parameters['keywords'] ?? '' ) );
+
+		return array(
+			'success'   => true,
+			'tool_name' => $this->tool_slug,
+			'data'      => array(
+				'action'    => 'list_recent_issues',
+				'repo'      => $repo,
+				'state'     => $state,
+				'keywords'  => $keywords,
+				'count'     => count( $issues ),
+				'issues'    => $issues,
+				'next_step' => 'Compare each issue title against the user\'s intent (and any keywords echoed above). If any look like the same idea, propose commenting on that existing issue with comment_on_issue. Otherwise proceed to file_issue.',
+			),
+		);
+	}
+
+	/**
+	 * comment_on_issue handler.
+	 *
+	 * @param array<string,mixed> $parameters Tool parameters.
+	 * @param string              $repo       Validated repo.
+	 * @return array<string,mixed>
+	 */
+	protected function handle_comment_on_issue( array $parameters, string $repo ): array {
+		$issue_number = (int) ( $parameters['issue_number'] ?? 0 );
+		if ( $issue_number <= 0 ) {
+			return $this->buildErrorResponse(
+				'issue_number is required for action=comment_on_issue and must be a positive integer.',
+				$this->tool_slug
+			);
+		}
+
+		$body = (string) ( $parameters['body'] ?? '' );
+		if ( '' === trim( $body ) ) {
+			return $this->buildErrorResponse(
+				'body is required for action=comment_on_issue.',
+				$this->tool_slug
+			);
+		}
+
+		$augmented_body = $this->augment_body_with_attribution( $body );
+
+		$input = array(
+			'repo'         => $repo,
+			'issue_number' => $issue_number,
+			'body'         => $augmented_body,
+		);
+
+		/**
+		 * Filter the input passed to `datamachine/comment-github-issue`.
+		 *
+		 * @since 0.8.0
+		 *
+		 * @param array  $input      Ability input.
+		 * @param array  $parameters Original tool parameters.
+		 * @param string $repo       Validated repo.
+		 */
+		$input = (array) apply_filters( 'extrachill_roadie_comment_issue_input', $input, $parameters, $repo );
+
+		$result = wp_get_ability( 'datamachine/comment-github-issue' )->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse(
+				'GitHub issue comment failed: ' . $result->get_error_message(),
+				$this->tool_slug
+			);
+		}
+
+		if ( ! is_array( $result ) ) {
+			return $this->buildErrorResponse(
+				'Unexpected response shape from datamachine/comment-github-issue.',
+				$this->tool_slug
+			);
+		}
+
+		$comment_url = (string) ( $result['html_url'] ?? $result['url'] ?? '' );
+
+		return array(
+			'success'   => true,
+			'tool_name' => $this->tool_slug,
+			'data'      => array(
+				'action'       => 'comment_on_issue',
+				'repo'         => $repo,
+				'issue_number' => $issue_number,
+				'comment_url'  => $comment_url,
+				'raw'          => $result,
+			),
+		);
+	}
+
+	/**
+	 * Add a "Filed via Roadie chat by <user>" footer to issue/comment bodies.
+	 *
+	 * Until extrachill-roadie#8 lands and the agent loop has reliable access
+	 * to `calling_user_id`, the human proposer's identity is captured from
+	 * `get_current_user_id()`. Once #8 lands, the agent can prefer the
+	 * calling user override and this fallback becomes the safety net.
+	 *
+	 * @param string $body Original body.
+	 * @return string Augmented body.
+	 */
+	protected function augment_body_with_attribution( string $body ): string {
+		$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+		$username = '';
+		$display  = '';
+
+		if ( $user_id > 0 && function_exists( 'get_userdata' ) ) {
+			$user = get_userdata( $user_id );
+			if ( $user ) {
+				$username = (string) ( $user->user_login ?? '' );
+				$display  = (string) ( $user->display_name ?? '' );
+			}
+		}
+
+		$site_url = function_exists( 'home_url' ) ? (string) home_url() : '';
+
+		$attribution_lines   = array( '', '---', '' );
+		$attribution_lines[] = '_Filed via Roadie chat._';
+
+		if ( '' !== $username ) {
+			$attribution_lines[] = sprintf(
+				'_Proposer: %s%s (WP user #%d)._',
+				$display !== '' ? $display . ' ' : '',
+				$username !== '' ? '(`' . $username . '`)' : '',
+				$user_id
+			);
+		} elseif ( $user_id > 0 ) {
+			$attribution_lines[] = sprintf( '_Proposer: WP user #%d._', $user_id );
+		}
+
+		if ( '' !== $site_url ) {
+			$attribution_lines[] = sprintf( '_Subsite: %s._', $site_url );
+		}
+
+		/**
+		 * Filter the attribution footer lines appended to filed issue and
+		 * comment bodies. Return an empty array to suppress the footer
+		 * entirely.
+		 *
+		 * @since 0.8.0
+		 *
+		 * @param string[] $attribution_lines Footer lines (already prefixed with separator).
+		 * @param int      $user_id           Current WP user id.
+		 * @param string   $username          Current WP user login.
+		 */
+		$attribution_lines = (array) apply_filters(
+			'extrachill_roadie_feature_request_attribution_lines',
+			$attribution_lines,
+			$user_id,
+			$username
+		);
+
+		if ( empty( $attribution_lines ) ) {
+			return $body;
+		}
+
+		return rtrim( $body ) . "\n" . implode( "\n", array_map( 'strval', $attribution_lines ) );
+	}
+
+	/**
+	 * Normalize GitHub issue labels to a flat string list.
+	 *
+	 * GitHub returns labels as an array of objects (`['name' => '...']`) when
+	 * fetched via the issues endpoint; some adapters flatten them already.
+	 * Handle both shapes.
+	 *
+	 * @param mixed $labels Raw labels value.
+	 * @return string[]
+	 */
+	protected function normalize_labels( $labels ): array {
+		if ( ! is_array( $labels ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $labels as $label ) {
+			if ( is_string( $label ) ) {
+				$out[] = $label;
+				continue;
+			}
+			if ( is_array( $label ) && isset( $label['name'] ) ) {
+				$out[] = (string) $label['name'];
+				continue;
+			}
+			if ( is_object( $label ) && isset( $label->name ) ) {
+				$out[] = (string) $label->name;
+			}
+		}
+		return array_values( array_filter( $out, static fn( $l ) => '' !== $l ) );
+	}
+}

--- a/inc/tools/class-file-feature-request.php
+++ b/inc/tools/class-file-feature-request.php
@@ -344,7 +344,7 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			)
 		);
 
-		$augmented_body = $this->augment_body_with_attribution( $body );
+		$augmented_body = $this->augment_body_with_attribution( $body, $parameters );
 
 		$input = array(
 			'repo'   => $repo,
@@ -505,7 +505,7 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			);
 		}
 
-		$augmented_body = $this->augment_body_with_attribution( $body );
+		$augmented_body = $this->augment_body_with_attribution( $body, $parameters );
 
 		$input = array(
 			'repo'         => $repo,
@@ -558,16 +558,31 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	/**
 	 * Add a "Filed via Roadie chat by <user>" footer to issue/comment bodies.
 	 *
-	 * Until extrachill-roadie#8 lands and the agent loop has reliable access
-	 * to `calling_user_id`, the human proposer's identity is captured from
-	 * `get_current_user_id()`. Once #8 lands, the agent can prefer the
-	 * calling user override and this fallback becomes the safety net.
+	 * Priority order for proposer identity (post #8):
+	 *   1. `$parameters['calling_user_id']` — the human on whose behalf the
+	 *      agent loop is running (set by `ChatOrchestrator` and propagated
+	 *      through `ToolParameters::buildParameters` per the
+	 *      `datamachine_get_calling_user_id()` contract).
+	 *   2. `get_current_user_id()` — fallback when the tool is invoked
+	 *      outside an agent loop (CLI, smoke test, direct REST).
 	 *
-	 * @param string $body Original body.
+	 * @param string $body       Original body.
+	 * @param array  $parameters Tool parameters (may carry `calling_user_id`).
 	 * @return string Augmented body.
 	 */
-	protected function augment_body_with_attribution( string $body ): string {
-		$user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+	protected function augment_body_with_attribution( string $body, array $parameters = array() ): string {
+		$user_id = 0;
+
+		if ( function_exists( 'datamachine_get_calling_user_id' ) ) {
+			$user_id = (int) datamachine_get_calling_user_id( $parameters );
+		} elseif ( isset( $parameters['calling_user_id'] ) ) {
+			$user_id = (int) $parameters['calling_user_id'];
+		}
+
+		if ( $user_id <= 0 && function_exists( 'get_current_user_id' ) ) {
+			$user_id = (int) get_current_user_id();
+		}
+
 		$username = '';
 		$display  = '';
 

--- a/inc/tools/register.php
+++ b/inc/tools/register.php
@@ -37,6 +37,7 @@ add_action(
 		require_once __DIR__ . '/class-manage-community.php';
 		require_once __DIR__ . '/class-propose-code-change.php';
 		require_once __DIR__ . '/class-apply-code-change.php';
+		require_once __DIR__ . '/class-file-feature-request.php';
 
 		new ECRoadie_ManageArtistProfile();
 		new ECRoadie_ManageLinkPage();
@@ -44,5 +45,6 @@ add_action(
 		new ECRoadie_ManageCommunity();
 		new ECRoadie_ProposeCodeChange();
 		new ECRoadie_ApplyCodeChange();
+		new ECRoadie_FileFeatureRequest();
 	}
 );

--- a/tests/feature-request-tool.php
+++ b/tests/feature-request-tool.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * Smoke tests for the file_feature_request chat tool.
+ *
+ * Covers:
+ *   - Tool registers via the datamachine_tools filter (chat mode, authenticated).
+ *   - Tool definition surfaces the three documented actions.
+ *   - Capability gate: users without extrachill_propose_code are blocked.
+ *   - Repo validation: rejects repos outside the EC slug-to-repo registry.
+ *   - Action validation: unknown actions are rejected with a clear error.
+ *   - file_issue: requires title + body, auto-applies default labels,
+ *     appends attribution footer, returns issue_url + issue_number.
+ *   - list_recent_issues: filters PRs out of the normalized list, respects
+ *     state defaulting, clamps per_page.
+ *   - comment_on_issue: requires positive issue_number + non-empty body,
+ *     returns comment_url.
+ *
+ * Run: php tests/feature-request-tool.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+
+// --- Test-local stubs ---------------------------------------------------
+
+if ( ! function_exists( 'get_userdata' ) ) {
+	function get_userdata( int $user_id ) {
+		$pool = $GLOBALS['extrachill_roadie_test_state']['users'] ?? array();
+		return $pool[ $user_id ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof ECRoadie_TestWPError;
+	}
+}
+
+if ( ! class_exists( 'ECRoadie_TestWPError' ) ) {
+	final class ECRoadie_TestWPError {
+		public function __construct( private string $code, private string $message ) {}
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_code(): string { return $this->code; }
+	}
+}
+
+if ( ! class_exists( 'ECRoadie_TestAbility' ) ) {
+	final class ECRoadie_TestAbility {
+		/**
+		 * @param callable(array):mixed $executor
+		 */
+		public function __construct( private string $name, private $executor ) {}
+
+		public function execute( array $input ) {
+			$GLOBALS['extrachill_roadie_test_state']['ability_calls'][] = array(
+				'name'  => $this->name,
+				'input' => $input,
+			);
+			return ( $this->executor )( $input );
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ) {
+		$registry = $GLOBALS['extrachill_roadie_test_state']['abilities'] ?? array();
+		return $registry[ $name ] ?? null;
+	}
+}
+
+// BaseTool stub: same shape used by contribute-code-tool-registration.php.
+if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
+	eval(
+		'namespace DataMachine\\Engine\\AI\\Tools;
+		abstract class BaseTool {
+			protected function registerTool( string $toolName, $toolDefinition, array $modes = array(), array $meta = array() ): void {
+				$GLOBALS["extrachill_roadie_test_state"]["registered_tools"][ $toolName ] = array(
+					"definition" => $toolDefinition,
+					"modes"      => $modes,
+					"meta"       => $meta,
+				);
+			}
+			protected function buildErrorResponse( string $error, string $tool_name ): array {
+				return array( "success" => false, "error" => $error, "tool_name" => $tool_name );
+			}
+			protected function buildDiagnosticErrorResponse( string $error, string $type, string $tool_name, array $a = array(), array $b = array() ): array {
+				return array( "success" => false, "error" => $error, "type" => $type, "tool_name" => $tool_name );
+			}
+		}'
+	);
+}
+
+$GLOBALS['extrachill_roadie_test_state']['registered_tools']  = array();
+$GLOBALS['extrachill_roadie_test_state']['ability_calls']     = array();
+$GLOBALS['extrachill_roadie_test_state']['abilities']         = array();
+$GLOBALS['extrachill_roadie_test_state']['users']             = array();
+$GLOBALS['extrachill_roadie_test_state']['current_user_id']   = 0;
+
+require_once dirname( __DIR__ ) . '/inc/tools/class-file-feature-request.php';
+
+$tool = new ECRoadie_FileFeatureRequest();
+
+// --- Registration -------------------------------------------------------
+
+roadie_test_assert(
+	isset( $GLOBALS['extrachill_roadie_test_state']['registered_tools']['file_feature_request'] ),
+	'file_feature_request must register via registerTool()'
+);
+
+$reg = $GLOBALS['extrachill_roadie_test_state']['registered_tools']['file_feature_request'];
+roadie_test_assert( in_array( 'chat', $reg['modes'], true ), 'tool must register for chat mode' );
+roadie_test_assert(
+	'authenticated' === ( $reg['meta']['access_level'] ?? '' ),
+	'tool must require authenticated access_level'
+);
+
+$definition = $tool->getToolDefinition();
+roadie_test_assert( 'handle_tool_call' === $definition['method'], 'tool dispatch method' );
+$required = $definition['parameters']['required'] ?? array();
+roadie_test_assert( in_array( 'action', $required, true ), 'definition requires action' );
+roadie_test_assert( in_array( 'repo', $required, true ), 'definition requires repo' );
+
+$action_enum = $definition['parameters']['properties']['action']['enum'] ?? array();
+roadie_test_assert( in_array( 'file_issue', $action_enum, true ), 'action enum includes file_issue' );
+roadie_test_assert( in_array( 'list_recent_issues', $action_enum, true ), 'action enum includes list_recent_issues' );
+roadie_test_assert( in_array( 'comment_on_issue', $action_enum, true ), 'action enum includes comment_on_issue' );
+
+// --- Capability gate ----------------------------------------------------
+
+$GLOBALS['extrachill_roadie_test_state']['user_caps'] = array();
+$blocked = $tool->handle_tool_call( array( 'action' => 'file_issue', 'repo' => 'Extra-Chill/extrachill-roadie', 'title' => 't', 'body' => 'b' ) );
+roadie_test_assert( false === $blocked['success'], 'caller without cap must be blocked' );
+roadie_test_assert(
+	false !== strpos( $blocked['error'] ?? '', 'permission' ),
+	'capability error must mention permission'
+);
+
+// Grant the cap for the rest of the suite.
+$GLOBALS['extrachill_roadie_test_state']['user_caps'][ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] = true;
+
+// --- Action + repo validation ------------------------------------------
+
+$bad_action = $tool->handle_tool_call( array( 'action' => 'delete_universe', 'repo' => 'Extra-Chill/extrachill-roadie' ) );
+roadie_test_assert( false === $bad_action['success'], 'unknown action must be rejected' );
+
+$missing_repo = $tool->handle_tool_call( array( 'action' => 'file_issue', 'repo' => '', 'title' => 't', 'body' => 'b' ) );
+roadie_test_assert( false === $missing_repo['success'], 'missing repo must be rejected' );
+
+$bad_repo = $tool->handle_tool_call( array( 'action' => 'file_issue', 'repo' => 'evil-org/private-secrets', 'title' => 't', 'body' => 'b' ) );
+roadie_test_assert( false === $bad_repo['success'], 'unregistered repo must be rejected' );
+roadie_test_assert(
+	false !== strpos( $bad_repo['error'] ?? '', 'registry' ),
+	'unregistered-repo error must mention the registry'
+);
+
+// --- file_issue: missing-ability error path ----------------------------
+
+$missing_ability = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'title'  => 't',
+	'body'   => 'b',
+) );
+roadie_test_assert( false === $missing_ability['success'], 'missing ability must surface error' );
+roadie_test_assert(
+	false !== strpos( $missing_ability['error'] ?? '', 'datamachine/create-github-issue' ),
+	'missing-ability error names the missing ability'
+);
+
+// --- Register stub abilities for the success-path tests ----------------
+
+$GLOBALS['extrachill_roadie_test_state']['abilities'] = array(
+	'datamachine/create-github-issue' => new ECRoadie_TestAbility(
+		'datamachine/create-github-issue',
+		static function ( array $input ): array {
+			return array(
+				'number'   => 42,
+				'html_url' => 'https://github.com/' . $input['repo'] . '/issues/42',
+				'title'    => $input['title'],
+				'labels'   => array_map(
+					static fn( $label ) => array( 'name' => $label ),
+					(array) ( $input['labels'] ?? array() )
+				),
+			);
+		}
+	),
+	'datamachine/list-github-issues'  => new ECRoadie_TestAbility(
+		'datamachine/list-github-issues',
+		static function ( array $input ): array {
+			return array(
+				array(
+					'number'     => 11,
+					'title'      => 'Existing idea',
+					'state'      => 'open',
+					'html_url'   => 'https://github.com/' . $input['repo'] . '/issues/11',
+					'labels'     => array( array( 'name' => 'feature-request' ), array( 'name' => 'roadie-submitted' ) ),
+					'updated_at' => '2026-05-01T00:00:00Z',
+				),
+				array(
+					'number'       => 12,
+					'title'        => 'A pull request',
+					'state'        => 'open',
+					'html_url'     => 'https://github.com/' . $input['repo'] . '/pull/12',
+					'pull_request' => array( 'url' => 'https://api.github.com/...' ),
+				),
+			);
+		}
+	),
+	'datamachine/comment-github-issue' => new ECRoadie_TestAbility(
+		'datamachine/comment-github-issue',
+		static function ( array $input ): array {
+			return array(
+				'id'       => 7777,
+				'html_url' => sprintf(
+					'https://github.com/%s/issues/%d#issuecomment-7777',
+					$input['repo'],
+					$input['issue_number']
+				),
+				'body'     => $input['body'],
+			);
+		}
+	),
+);
+
+// --- file_issue: requires title + body ---------------------------------
+
+$no_title = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'title'  => '',
+	'body'   => 'body',
+) );
+roadie_test_assert( false === $no_title['success'], 'file_issue without title fails' );
+
+$no_body = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'title'  => 't',
+	'body'   => '',
+) );
+roadie_test_assert( false === $no_body['success'], 'file_issue without body fails' );
+
+// --- file_issue: success path + attribution + default labels -----------
+
+$GLOBALS['extrachill_roadie_test_state']['current_user_id'] = 7;
+$GLOBALS['extrachill_roadie_test_state']['users'][7] = (object) array(
+	'user_login'   => 'chubes',
+	'display_name' => 'Chris Huber',
+);
+$GLOBALS['extrachill_roadie_test_state']['ability_calls'] = array();
+
+$filed = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'title'  => 'FAB needs a brighter color',
+	'body'   => 'Make the floating action button pop more so users notice it on first paint.',
+	'labels' => array( 'ui-polish', 'roadie-submitted' /* duplicate; should dedupe */ ),
+) );
+roadie_test_assert( true === $filed['success'], 'file_issue success path returns success' );
+roadie_test_assert( 42 === ( $filed['data']['issue_number'] ?? 0 ), 'file_issue returns issue_number from ability' );
+roadie_test_assert(
+	'https://github.com/Extra-Chill/extrachill-roadie/issues/42' === ( $filed['data']['issue_url'] ?? '' ),
+	'file_issue returns issue_url from html_url'
+);
+
+$call = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert( 'datamachine/create-github-issue' === $call['name'], 'file_issue calls create-github-issue ability' );
+roadie_test_assert(
+	in_array( 'roadie-submitted', $call['input']['labels'], true ),
+	'file_issue auto-applies roadie-submitted label'
+);
+roadie_test_assert(
+	in_array( 'feature-request', $call['input']['labels'], true ),
+	'file_issue auto-applies feature-request label'
+);
+roadie_test_assert(
+	in_array( 'ui-polish', $call['input']['labels'], true ),
+	'file_issue preserves caller-supplied labels'
+);
+$label_counts = array_count_values( $call['input']['labels'] );
+roadie_test_assert(
+	1 === ( $label_counts['roadie-submitted'] ?? 0 ),
+	'file_issue dedupes duplicate labels'
+);
+
+roadie_test_assert(
+	false !== strpos( $call['input']['body'], 'Filed via Roadie chat' ),
+	'file_issue body carries attribution footer'
+);
+roadie_test_assert(
+	false !== strpos( $call['input']['body'], 'chubes' ),
+	'file_issue body attribution includes WP login'
+);
+roadie_test_assert(
+	false !== strpos( $call['input']['body'], '#7' ),
+	'file_issue body attribution includes WP user id'
+);
+roadie_test_assert(
+	false !== strpos( $call['input']['body'], 'extrachill.test' ),
+	'file_issue body attribution includes subsite URL'
+);
+
+// --- list_recent_issues: PR filtering, normalization, defaults ---------
+
+$listed = $tool->handle_tool_call( array(
+	'action' => 'list_recent_issues',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+) );
+roadie_test_assert( true === $listed['success'], 'list_recent_issues success path' );
+roadie_test_assert( 1 === ( $listed['data']['count'] ?? -1 ), 'list_recent_issues filters PRs out of normalized list' );
+$issues = $listed['data']['issues'] ?? array();
+roadie_test_assert( 1 === count( $issues ), 'normalized issue list has exactly one entry' );
+roadie_test_assert( 11 === ( $issues[0]['number'] ?? 0 ), 'normalized issue carries the right number' );
+roadie_test_assert(
+	in_array( 'feature-request', $issues[0]['labels'] ?? array(), true ),
+	'normalized issue label array contains feature-request'
+);
+
+$last = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert( 'open' === ( $last['input']['state'] ?? '' ), 'list_recent_issues defaults state to open' );
+roadie_test_assert( 20 === ( $last['input']['per_page'] ?? 0 ), 'list_recent_issues defaults per_page to 20' );
+
+// per_page clamping
+$tool->handle_tool_call( array(
+	'action'   => 'list_recent_issues',
+	'repo'     => 'Extra-Chill/extrachill-roadie',
+	'per_page' => 999,
+) );
+$last_clamp = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert( 100 === ( $last_clamp['input']['per_page'] ?? 0 ), 'list_recent_issues clamps per_page to 100' );
+
+// invalid state falls back to open
+$tool->handle_tool_call( array(
+	'action' => 'list_recent_issues',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'state'  => 'invalid',
+) );
+$last_state = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert( 'open' === ( $last_state['input']['state'] ?? '' ), 'list_recent_issues falls back to open on bad state' );
+
+// --- comment_on_issue: validation + success ----------------------------
+
+$no_num = $tool->handle_tool_call( array(
+	'action' => 'comment_on_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'body'   => 'lgtm',
+) );
+roadie_test_assert( false === $no_num['success'], 'comment_on_issue without issue_number fails' );
+
+$no_body = $tool->handle_tool_call( array(
+	'action'       => 'comment_on_issue',
+	'repo'         => 'Extra-Chill/extrachill-roadie',
+	'issue_number' => 42,
+	'body'         => '',
+) );
+roadie_test_assert( false === $no_body['success'], 'comment_on_issue without body fails' );
+
+$commented = $tool->handle_tool_call( array(
+	'action'       => 'comment_on_issue',
+	'repo'         => 'Extra-Chill/extrachill-roadie',
+	'issue_number' => 42,
+	'body'         => 'Following up — same idea here.',
+) );
+roadie_test_assert( true === $commented['success'], 'comment_on_issue success' );
+roadie_test_assert(
+	false !== strpos( $commented['data']['comment_url'] ?? '', 'issuecomment-7777' ),
+	'comment_on_issue surfaces the comment URL'
+);
+
+$last_comment = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert(
+	false !== strpos( $last_comment['input']['body'], 'Filed via Roadie chat' ),
+	'comment_on_issue body carries attribution footer'
+);
+
+// --- WP_Error propagation ---------------------------------------------
+
+$GLOBALS['extrachill_roadie_test_state']['abilities']['datamachine/create-github-issue'] = new ECRoadie_TestAbility(
+	'datamachine/create-github-issue',
+	static fn( array $i ) => new ECRoadie_TestWPError( 'gh_error', 'GitHub API exploded.' )
+);
+
+$errored = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'title'  => 'x',
+	'body'   => 'y',
+) );
+roadie_test_assert( false === $errored['success'], 'WP_Error from ability surfaces as failure' );
+roadie_test_assert(
+	false !== strpos( $errored['error'] ?? '', 'GitHub API exploded' ),
+	'WP_Error message is forwarded to caller'
+);
+
+echo "feature-request tool smoke passed.\n";


### PR DESCRIPTION
Closes #17.

## Summary

Adds the `file_feature_request` Roadie chat tool: lets team members file (or dedupe-check, or comment on) GitHub issues against EC repos without leaving the chat surface. Companion to `propose_code_change` (PR #13) — different intent, no sandbox, no PR creation. Lightweight idea capture.

Three actions, all backed by existing `datamachine/*` abilities:

| Action | Backing ability | Required input |
|---|---|---|
| `file_issue` | `datamachine/create-github-issue` | `repo`, `title`, `body` |
| `list_recent_issues` | `datamachine/list-github-issues` | `repo` (state defaults `open`, per_page clamped 1–100) |
| `comment_on_issue` | `datamachine/comment-github-issue` | `repo`, `issue_number`, `body` |

## Design decisions

- **Reuses `extrachill_propose_code` capability** per the issue spec. Anyone who can propose a code change can also file an idea — no parallel cap to grant, no extra operator surface.
- **Reuses `inc/contribute-code/repo-map.php` as the allowlist.** Cross-org repos and unmapped repos are rejected so the GitHub PAT can never be turned into a write surface against repos the operator never intended to expose. Filterable via `extrachill_roadie_feature_request_allowed_repos` if a one-off expansion is needed.
- **Auto-labels every issue** with `roadie-submitted` + `feature-request`, deduped against caller-supplied labels. Default label list is filterable.
- **Attribution footer.** Every issue and comment body gets a `Filed via Roadie chat / Proposer: <name> (<login>) (WP user #N) / Subsite: <url>` footer. Falls back gracefully when `get_userdata` is missing. Filterable via `extrachill_roadie_feature_request_attribution_lines`.
- **PR filtering.** GitHub's issues endpoint returns PRs too; `list_recent_issues` strips them out so dedupe only compares issue-to-issue.

## Registry extension

The `repo-map.php` registry now distinguishes three kinds of EC plugins:

| Kind | Behavior |
|---|---|
| `plugin` | Subsite-specific. Auto-mounted readwrite in `propose_code_change` recipes. **Unchanged.** |
| `platform-plugin` | **New.** Network-wide platform boilerplate. Issue-trackable + code-trackable but never auto-mounted as editable when a contributor is on a subsite. |
| `agent-stack-plugin` | Read-only references the sandboxed agent greps. **Unchanged.** |

Adds `extrachill-roadie` + 11 other `extrachill-*` platform plugins (users, multisite, api, admin-tools, newsletter, search, seo, analytics, cli, tokens, components) to the registry under `platform-plugin`. This unblocks the canonical issue-17 use case (\"user notices the Roadie FAB needs polish → file against `Extra-Chill/extrachill-roadie`\") and makes every EC platform plugin issue-trackable from chat.

`recipe-builder.php` explicitly skips `platform-plugin` kinds as defense-in-depth against future drift of the subsite-context exclusion list (the current exclusion list already filters them out before they reach the builder, so this is belt-and-suspenders).

Also adds `extrachill-tokens` and `extrachill-components` to the subsite-context exclusion list — they're network-active platform infra that don't belong as a subsite's editable surface.

## Tests

New `tests/feature-request-tool.php` (29 assertions):

```
$ php tests/feature-request-tool.php
feature-request tool smoke passed.
```

Coverage:

- Tool registration via `datamachine_tools` (chat mode, authenticated access_level)
- Tool definition shape (required fields, action enum)
- Capability gate: caller without `extrachill_propose_code` is blocked
- Action validation: unknown actions rejected with clear error
- Repo validation: unregistered repos rejected, error names the registry
- `file_issue`: required title + body, auto-applied default labels, deduped duplicate labels, attribution footer (WP login + user id + subsite URL)
- `list_recent_issues`: PR filtering, default state `open`, fallback on invalid state, per_page clamp to 100
- `comment_on_issue`: positive issue_number required, non-empty body required, attribution footer on comment body
- WP_Error propagation from underlying ability

All 7 existing test files still green:

```
contribute-code-capabilities.php: contribute-code capabilities smoke passed.
contribute-code-inherit-resolver.php: contribute-code inherit-resolver smoke passed.
contribute-code-recipe-builder.php: contribute-code recipe-builder smoke passed.
contribute-code-subsite-context.php: contribute-code subsite-context smoke passed.
contribute-code-tool-registration.php: contribute-code tool-registration smoke passed.
feature-request-tool.php: feature-request tool smoke passed.
frontend-chat-branding-smoke.php: Roadie frontend chat branding smoke passed (3 assertions).
```

## Acceptance criteria (from #17)

- [x] `file_feature_request` tool registered via `datamachine_tools`, available to the roadie agent
- [x] Tool actions: `file_issue`, `list_recent_issues`, `comment_on_issue`
- [x] Repo inference works for all EC subsites + platform plugins (via the registry; extended with `platform-plugin` kind so `extrachill-roadie` itself is filable)
- [x] Permission gate: `extrachill_propose_code`
- [x] Auto-labels applied: `roadie-submitted`, `feature-request`
- [x] Smoke test: tool registration + capability denial + file_issue + list/dedupe + comment_on_issue
- [x] Non-team user blocked with clean permission-denied response
- [x] Dedupe flow tested (list_recent_issues PR-filter + state defaults + per_page clamp)

## Out of scope (deferred to follow-ups)

- **Per-user GitHub OAuth so the actual proposer is the GitHub author.** Today everything is filed under the PAT owner (@chubes) with proposer noted in body. Tracked indirectly via #11's stretch; lives in extrachill-users when it lands.
- **#8 calling_user_id propagation.** Until #8 lands, the attribution footer uses `get_current_user_id()` directly. When #8 lands, the tool can prefer the calling-user override and keep `get_current_user_id()` as fallback. No code change needed in this PR for that — the attribution function reads from a single point so it's a small swap later.
- **Cross-repo filing into non-EC repos.** The registry-as-allowlist intentionally locks this down. If/when we want to file into, e.g., `chubes4/wp-codebox`, add an explicit `Extra-Chill-affiliated-upstreams` block to the registry.

## Notes for reviewer

- The registry expansion deserves its own line of attention — it touches `repo-map.php` which is a shared substrate for both the contribute-code and feature-request flows. The `platform-plugin` kind is the cleanest way I could find to expand the issue-tracking allowlist without weakening the readwrite-mount safety story for `propose_code_change`. Open to a different shape if you'd rather keep `repo-map.php` minimal and put the feature-request allowlist somewhere else.
- No `CHANGELOG.md` edit, no version bump — homeboy owns both per repo conventions.
- Conventional commit message used (`feat(tools): ...`).