### PR TITLE
feat(agent-mode): adopt AgentModeRegistry for roadie mode + calling_user_id propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,65 @@ User (chat) → Data Machine → Roadie Tool → ec_cross_site_rest_request() �
 
 All tools extend `ECRoadie_PlatformTool`, which extends Data Machine's `BaseTool` and provides:
 
-- **`rest_request()`** — Cross-site REST calls via `ec_cross_site_rest_request()` (internal HTTP to localhost with HMAC auth)
-- **`get_blog_id()`** — Site key resolution for safe data reads via `switch_to_blog()`
+- **`rest_request( $method, $path, $args )`** — Cross-site REST calls via `ec_cross_site_rest_request()`. Pass `user_id` in `$args` to authenticate the request as that user; the underlying helper wraps `wp_set_current_user()` in a try/finally so context restores cleanly.
+- **`get_blog_id()`** — Site key resolution for safe data reads via `switch_to_blog()`.
+- **`get_calling_user_id( $parameters )`** — Reads `calling_user_id` from the merged tool parameters. Data Machine's loop merges the invocation payload into `$parameters` before calling `handle_tool_call()`, so the human caller is always available as `$parameters['calling_user_id']`.
+- **`resolve_acting_user_id( $parameters )`** — Returns the user the tool should act as. Priority: explicit `user_id` input → `calling_user_id` → `get_current_user_id()`.
+- **`assert_acting_user_allowed( $acting, $parameters )`** — Returns a clean permission-denied response (or `null` when allowed). Non-admin callers attempting to act on another user are refused.
 
 Each tool declares a `$site_key` (e.g. `'artist'`, `'community'`, `'main'`) and a `$tool_slug` for error context.
+
+### Agent Mode
+
+Roadie registers a `roadie` execution mode with Data Machine's `AgentModeRegistry`. The mode is the operating context for the EC platform tool surface — it composes EC-specific guidance (network topology, tool selection, identity contract, editorial voice, operating posture) into the AI prompt at directive priority 22.
+
+```php
+// inc/agent-mode/register.php
+add_action( 'datamachine_agent_modes', function () {
+    \DataMachine\Engine\AI\AgentModeRegistry::register( 'roadie', 45, array(
+        'label'       => __( 'Extra Chill Platform', 'extrachill-roadie' ),
+        'description' => __( 'Artist profiles, link pages, user profiles, community forum, and personal user-scoped operations on the EC multisite network.', 'extrachill-roadie' ),
+    ) );
+} );
+
+add_filter( 'datamachine_agent_mode_roadie', 'extrachill_roadie_mode_guidance', 10, 2 );
+```
+
+The mode is **agent-agnostic** — any agent (extra-chill-bot, roadie, or a custom one) can run in this mode and inherit the same platform guidance. Priority `45` places it after `data-machine-editor` (`40`) so editor mode wins when both are active in the same invocation (rare).
+
+### Calling-User Identity Contract
+
+Every Roadie tool sees the human caller via `$parameters['calling_user_id']`. The chat orchestrator sets this from the chat session caller; pipeline runs and system tasks set it to `0`.
+
+The contract for tool wiring:
+
+1. Resolve the acting user once at the top of `handle_tool_call()`:
+   ```php
+   $acting_user_id = $this->resolve_acting_user_id( $parameters );
+   $denied = $this->assert_acting_user_allowed( $acting_user_id, $parameters );
+   if ( null !== $denied ) {
+       return $denied;
+   }
+   ```
+2. Pass `'user_id' => $acting_user_id` into every `rest_request()` so the cross-site helper switches context correctly.
+3. For tools that read user-scoped data directly (e.g. `get_user_meta`), use `$acting_user_id` instead of `get_current_user_id()`.
+4. Public read actions (e.g. `list_forums`) can skip the resolve/assert pair entirely.
+
+Admin agents may target another user by passing an explicit `user_id` input; non-admins attempting that get a clean permission-denied response.
+
+### Adding a New Roadie Tool
+
+The pattern that lands a new EC platform tool:
+
+1. Create `inc/tools/class-<name>.php` extending `ECRoadie_PlatformTool`.
+2. Declare `$site_key` (which subsite the route belongs to) and `$tool_slug`.
+3. In the constructor, call `$this->registerTool( '<slug>', [ $this, 'getToolDefinition' ], [ 'chat' ], [ 'access_level' => 'authenticated' ] )`.
+4. Implement `getToolDefinition()` — include an optional `user_id` input parameter in the schema so admins can override.
+5. Implement `handle_tool_call( array $parameters, array $tool_def = array() )` — start with the resolve + assert pair above.
+6. Use `$this->rest_request()` for every cross-site call. Pass `user_id` in `$args`.
+7. Add the `require_once` + `new ECRoadie_<Name>()` lines to `inc/tools/register.php`.
+
+Mode-specific guidance for the new tool can be folded into the existing `extrachill_roadie_mode_guidance()` callback — there is no need for a separate mode unless the tool lives in a different operating context.
 
 ### Permissions
 
@@ -117,6 +172,8 @@ Profile links support types: `website`, `facebook`, `instagram`, `twitter`, `you
 | Filter | Description |
 |--------|-------------|
 | `datamachine_tools` | Registers all four chat tools (via BaseTool) |
+| `datamachine_agent_modes` | Registers the `roadie` execution mode with AgentModeRegistry |
+| `datamachine_agent_mode_roadie` | Provides the roadie mode guidance string (network topology, tool selection, identity contract, editorial voice, operating posture) |
 | `datamachine_can_access_agent` | Bridges EC team membership to Roadie agent access |
 | `datamachine_bridge_onboarding_config` | Provides Roadie-specific onboarding for bridge clients |
 | `extrachill_roadie_allowed_redirect_uris` | External redirect URIs allowed for bridge auth |
@@ -129,9 +186,11 @@ extrachill-roadie.php          # Plugin bootstrap
 inc/
   permissions.php              # Team access bridge + agent policy sync
   onboarding.php               # Bridge onboarding config (Beeper/Matrix)
+  agent-mode/
+    register.php               # AgentModeRegistry registration + roadie mode guidance
   tools/
     register.php               # Tool registration on plugins_loaded
-    class-ec-platform-tool.php # Base class with cross-site REST helper
+    class-ec-platform-tool.php # Base class — REST helper, calling-user resolution, permission guard
     class-manage-artist-profile.php
     class-manage-link-page.php
     class-manage-user-profile.php

--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -26,6 +26,7 @@ define( 'EXTRACHILL_ROADIE_VERSION', '0.7.0' );
 define( 'EXTRACHILL_ROADIE_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_ROADIE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
+require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/agent-mode/register.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/tools/register.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/permissions.php';
 require_once EXTRACHILL_ROADIE_PLUGIN_DIR . 'inc/frontend-chat.php';

--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Roadie Agent Mode Registration
+ *
+ * Registers the `roadie` execution mode with Data Machine's AgentModeRegistry
+ * and provides the mode-specific guidance string via the
+ * `datamachine_agent_mode_roadie` filter.
+ *
+ * The mode is the operating context for the Extra Chill platform tool surface
+ * — the artist profile, link page, user profile, and community forum tools.
+ * Registration is intentionally agent-agnostic: any agent (extra-chill-bot,
+ * roadie, or a custom one) can run in this mode and get the same platform
+ * guidance composed into the prompt.
+ *
+ * Reference implementation: data-machine-editor registers `editor` mode the
+ * same way at priority 40. We use priority 45 so editor mode wins in the
+ * (rare) case both modes are active in the same invocation.
+ *
+ * @package ExtraChillRoadie\AgentMode
+ * @since 0.8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the `roadie` execution mode with Data Machine.
+ *
+ * Fires inside the `datamachine_agent_modes` action — the registry consumes
+ * registrations the first time it resolves the mode list.
+ *
+ * @since 0.8.0
+ * @return void
+ */
+add_action(
+	'datamachine_agent_modes',
+	function (): void {
+		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\AgentModeRegistry' ) ) {
+			return;
+		}
+
+		\DataMachine\Engine\AI\AgentModeRegistry::register(
+			'roadie',
+			45,
+			array(
+				'label'       => __( 'Extra Chill Platform', 'extrachill-roadie' ),
+				'description' => __(
+					'Artist profiles, link pages, user profiles, community forum, and personal user-scoped operations on the EC multisite network.',
+					'extrachill-roadie'
+				),
+			)
+		);
+	}
+);
+
+/**
+ * Provide the `roadie` mode guidance via the directive filter.
+ *
+ * The filter callback receives the current directive content and the full
+ * invocation payload. We append a focused mode guidance block that explains
+ * the EC platform topology, available tool domains, calling-user contract,
+ * editorial voice, and operating posture for any agent acting through the
+ * Roadie tool surface.
+ *
+ * @since 0.8.0
+ *
+ * @param string $content Current directive content for the roadie mode.
+ * @param array  $payload Full AI invocation payload.
+ * @return string Mode guidance composed with prior content.
+ */
+add_filter( 'datamachine_agent_mode_roadie', 'extrachill_roadie_mode_guidance', 10, 2 );
+
+function extrachill_roadie_mode_guidance( string $content, array $payload ): string {
+	$calling_user_id = 0;
+	if ( function_exists( 'datamachine_get_calling_user_id' ) ) {
+		$calling_user_id = datamachine_get_calling_user_id( $payload );
+	} elseif ( isset( $payload['calling_user_id'] ) && is_numeric( $payload['calling_user_id'] ) ) {
+		$calling_user_id = max( 0, (int) $payload['calling_user_id'] );
+	}
+
+	$identity_line = $calling_user_id > 0
+		? sprintf(
+			'You are responding to a request from user #%d. Tools that take a `user_id` input default to this user when the input is omitted.',
+			$calling_user_id
+		)
+		: 'There is no human caller for this invocation (system task, scheduled job, or background pipeline). Tools that need a `user_id` will not have a default — supply one explicitly or skip user-scoped actions.';
+
+	$guidance = <<<MD
+# Extra Chill Platform Context
+
+This context is active when you operate against the Extra Chill multisite network — a publication and community platform for independent music. You have a tool surface for managing artist profiles, link pages, user profiles, and the community forum.
+
+## Network Topology
+
+Extra Chill runs as a WordPress multisite across nine subdomains. Identity (users, roles, capabilities) is network-wide; content is per-site. The tools handle cross-site routing internally via the `ec_cross_site_rest_request()` helper — you do not need to think about which site a request lands on.
+
+- **extrachill.com** — main publication (music news, features, reviews)
+- **community.extrachill.com** — forums, topics, replies, notifications
+- **artist.extrachill.com** — artist profiles and link pages
+- **shop.extrachill.com** — merch and music store
+- **events.extrachill.com** — events calendar
+- **newsletter.extrachill.com** — newsletter management
+- **docs.extrachill.com** — documentation
+- **wire.extrachill.com** — news wire
+- **studio.extrachill.com** — studio
+
+## Available Tool Domains
+
+- `manage_artist_profile` — list, get, create, and update artist profiles. Auto-resolves `artist_id` when the calling user manages exactly one artist.
+- `manage_link_page` — get, edit links, edit socials, edit styles, edit settings on an artist's public link page. Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save dance for you.
+- `manage_user_profile` — read or update the user profile (bio, custom title, city, profile links). Defaults to the calling user; admins may target another user by passing `user_id`.
+- `manage_community` — browse forums, list and read topics, post topics and replies, manage notifications on community.extrachill.com.
+
+Reach for the tool whose domain matches the request. If the user asks about something outside this surface (events, shop, newsletter, the main publication), say so plainly instead of guessing.
+
+## Calling-User Identity Contract
+
+{$identity_line}
+
+- When `user_id` is supplied explicitly to a tool, the tool acts on behalf of that user — but only if you have the capability. Non-admin agents cannot impersonate other users; the tool returns a clean permission error in that case.
+- The community tool (`manage_community`) attributes forum posts and replies to the calling user, not to the agent. Do not post on someone else's behalf without their request.
+- When there is no human caller (calling user is 0), avoid user-scoped writes. Read-only actions (lookups, listings) are fine.
+
+## Cross-Site Conventions
+
+- Identity is network-wide — a user has the same ID and capabilities on every site.
+- Content lives on its origin site. The tools switch blogs internally; you do not.
+- Permissions are checked against the route's target site, not the site you happen to be calling from.
+- Cross-site reads via `switch_to_blog()` are safe; writes go through REST so capability checks run in the right context.
+
+## Editorial Voice
+
+Extra Chill is an independent, grassroots music platform — not a corporate publication. When generating content (bios, topic posts, replies, profile copy):
+
+- Music-forward, knowledgeable, approachable.
+- "Extra chill" — relaxed but focused.
+- Authentic, not promotional. Avoid marketing-speak, hype, and corporate filler.
+- Respect the user's voice. Suggest, don't overwrite.
+
+## Operating Mode
+
+- **Lookups and reads** — act immediately. The user expects fast answers.
+- **Content changes** — propose then act. Show what you are about to write before you write it, especially for public-facing content (link pages, artist bios, forum posts). One short proposal is enough; do not over-explain.
+- **Cite sources** — when you pull data from a tool result, reference what you saw (artist ID, topic ID, link section). This makes corrections cheap.
+- **Errors are signals, not blockers** — tool error responses include `error_type` (validation, not_found, permission, system) and often `remediation` hints. Read them and adjust; do not retry blindly.
+MD;
+
+	if ( '' === trim( $content ) ) {
+		return $guidance;
+	}
+
+	return $content . "\n\n" . $guidance;
+}

--- a/inc/tools/class-ec-platform-tool.php
+++ b/inc/tools/class-ec-platform-tool.php
@@ -38,10 +38,15 @@ abstract class ECRoadie_PlatformTool extends BaseTool {
 	/**
 	 * Make a REST API request to this tool's target site.
 	 *
-	 * Routes through ec_cross_site_rest_request() which makes an internal
-	 * HTTP call to the correct subsite via localhost. The route affinity
-	 * middleware ensures the request reaches the right WordPress instance
-	 * with the correct plugins and abilities loaded.
+	 * Routes through ec_cross_site_rest_request() which dispatches in-process
+	 * via switch_to_blog() + rest_do_request() (or HTTP loopback when the
+	 * `ec_cross_site_use_http_loopback` filter is true for the route). The
+	 * helper handles wp_set_current_user() in a try/finally when a `user_id`
+	 * is supplied in $args — so authentication switches cleanly without the
+	 * caller having to manage user-context juggling.
+	 *
+	 * @since 0.5.0
+	 * @since 0.8.0 Accepts `user_id` in $args for calling-user propagation.
 	 *
 	 * @param string $method HTTP method (GET, POST, PUT, DELETE).
 	 * @param string $path   REST path without namespace (e.g. '/community/topics').
@@ -49,6 +54,8 @@ abstract class ECRoadie_PlatformTool extends BaseTool {
 	 *                       - 'body'    => array  Request body for POST/PUT.
 	 *                       - 'query'   => array  Query parameters for GET.
 	 *                       - 'headers' => array  Additional headers.
+	 *                       - 'user_id' => int    Authenticate as this user for the request.
+	 *                                             Defaults to current user when omitted.
 	 * @return array Tool response array with success/data or error.
 	 */
 	protected function rest_request( string $method, string $path, array $args = array() ): array {
@@ -95,5 +102,126 @@ abstract class ECRoadie_PlatformTool extends BaseTool {
 			return ec_get_blog_id( $key );
 		}
 		return null;
+	}
+
+	/**
+	 * Read the calling user ID from the merged tool parameters.
+	 *
+	 * Data Machine's ToolParameters::buildParameters() merges the loop payload
+	 * INTO the tool's $parameters array before calling handle_tool_call(). The
+	 * loop payload sets `calling_user_id` from the chat orchestrator's loop
+	 * context — so every tool sees it as $parameters['calling_user_id'].
+	 *
+	 * Returns 0 when absent, non-numeric, or non-positive — matching the
+	 * datamachine_get_calling_user_id() contract from data-machine core.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param array $parameters Tool parameters (post payload-merge).
+	 * @return int Non-negative user ID. 0 means "no human caller".
+	 */
+	protected function get_calling_user_id( array $parameters ): int {
+		// Prefer the canonical core helper when available so we stay in sync
+		// with any future contract changes.
+		if ( function_exists( 'datamachine_get_calling_user_id' ) ) {
+			return datamachine_get_calling_user_id( $parameters );
+		}
+
+		$raw = $parameters['calling_user_id'] ?? 0;
+		if ( ! is_numeric( $raw ) ) {
+			return 0;
+		}
+
+		$user_id = (int) $raw;
+		return $user_id > 0 ? $user_id : 0;
+	}
+
+	/**
+	 * Resolve the user ID this invocation should act on behalf of.
+	 *
+	 * Priority order:
+	 *   1. Explicit `user_id` input from the AI (override).
+	 *   2. `calling_user_id` from the loop payload (human caller in chat).
+	 *   3. `get_current_user_id()` as last resort (REST/CLI without explicit
+	 *      calling-user context).
+	 *
+	 * Returns 0 only when no user is resolvable — caller must handle that
+	 * case explicitly (typically a "you must be logged in" error response).
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @return int Resolved acting user ID, or 0 when none is available.
+	 */
+	protected function resolve_acting_user_id( array $parameters ): int {
+		if ( isset( $parameters['user_id'] ) && is_numeric( $parameters['user_id'] ) ) {
+			$explicit = (int) $parameters['user_id'];
+			if ( $explicit > 0 ) {
+				return $explicit;
+			}
+		}
+
+		$calling = $this->get_calling_user_id( $parameters );
+		if ( $calling > 0 ) {
+			return $calling;
+		}
+
+		$current = (int) get_current_user_id();
+		return $current > 0 ? $current : 0;
+	}
+
+	/**
+	 * Assert that the current actor is allowed to act on behalf of the given user.
+	 *
+	 * Rules:
+	 *   - Acting on yourself is always allowed.
+	 *   - Acting on another user requires `manage_options` on the caller.
+	 *   - Acting with no resolvable user is denied.
+	 *
+	 * Returns null when allowed, or a standardized permission-denied response
+	 * when forbidden. Callers should `return` the response immediately when
+	 * non-null.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param int   $acting_user_id The user the tool would act as.
+	 * @param array $parameters     Tool parameters (used to detect explicit user_id override).
+	 * @return array|null Error response when denied, null when allowed.
+	 */
+	protected function assert_acting_user_allowed( int $acting_user_id, array $parameters ): ?array {
+		if ( $acting_user_id <= 0 ) {
+			return $this->buildErrorResponse(
+				'No user context available for this action. Sign in or provide an explicit user_id.',
+				$this->tool_slug
+			);
+		}
+
+		$calling = $this->get_calling_user_id( $parameters );
+
+		// Effective caller: the human on whose behalf the agent is acting in
+		// this invocation. Fall back to the current WP user when there is no
+		// chat caller (REST/CLI contexts).
+		$caller = $calling > 0 ? $calling : (int) get_current_user_id();
+
+		// Acting as yourself, or no caller at all (system task), is allowed.
+		// System tasks (calling_user_id = 0, current_user = 0) reach internal
+		// abilities directly and have their own permission gates.
+		if ( $caller <= 0 || $caller === $acting_user_id ) {
+			return null;
+		}
+
+		// Different user — admin-only.
+		if ( user_can( $caller, 'manage_options' ) ) {
+			return null;
+		}
+
+		return $this->buildErrorResponse(
+			sprintf(
+				'Permission denied: only administrators can act on behalf of another user (caller #%d → target #%d).',
+				$caller,
+				$acting_user_id
+			),
+			$this->tool_slug
+		);
 	}
 }

--- a/inc/tools/class-manage-artist-profile.php
+++ b/inc/tools/class-manage-artist-profile.php
@@ -8,6 +8,9 @@
  *
  * @package ExtraChillRoadie\Tools
  * @since 0.1.0
+ * @since 0.8.0 Calling-user identity propagation: list/get/create/update act
+ *              on behalf of the calling user (or an explicit user_id when
+ *              admins override).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -32,13 +35,17 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Manage artist profiles on the Extra Chill platform. Can list the current user\'s artists, get artist details, create a new artist profile, or update an existing one (name, bio, genre, city, images). If the user has only one artist, it is auto-selected.',
+			'description' => 'Manage artist profiles on the Extra Chill platform. Defaults to the calling user. Admins can target another user by passing user_id. Can list a user\'s artists, get artist details, create a new artist profile, or update an existing one (name, bio, genre, city, images). If the user has only one artist, it is auto-selected.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
 					'action'           => array(
 						'type'        => 'string',
 						'description' => 'Action to perform: "list" (list user\'s artists), "get" (get artist details), "create" (create new artist), "update" (update existing artist)',
+					),
+					'user_id'          => array(
+						'type'        => 'integer',
+						'description' => 'Target user ID for list/create/auto-resolve. Optional. Defaults to the calling user. Admin-only override.',
 					),
 					'artist_id'        => array(
 						'type'        => 'integer',
@@ -75,17 +82,24 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$acting_user_id = $this->resolve_acting_user_id( $parameters );
+
+		$denied = $this->assert_acting_user_allowed( $acting_user_id, $parameters );
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
 		$action = $parameters['action'] ?? '';
 
 		switch ( $action ) {
 			case 'list':
-				return $this->handle_list();
+				return $this->handle_list( $acting_user_id );
 			case 'get':
-				return $this->handle_get( $parameters );
+				return $this->handle_get( $parameters, $acting_user_id );
 			case 'create':
-				return $this->handle_create( $parameters );
+				return $this->handle_create( $parameters, $acting_user_id );
 			case 'update':
-				return $this->handle_update( $parameters );
+				return $this->handle_update( $parameters, $acting_user_id );
 			default:
 				return $this->buildErrorResponse(
 					'Invalid action "' . $action . '". Use: list, get, create, update.',
@@ -95,14 +109,14 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 	}
 
 	/**
-	 * List the current user's artist profiles.
+	 * List the acting user's artist profiles.
 	 *
 	 * Artist IDs are stored in user meta (network-wide), but we need to
 	 * read post data from the artist blog via switch_to_blog (safe for
 	 * data reads — only abilities fail cross-site).
 	 */
-	private function handle_list(): array {
-		$user_id    = get_current_user_id();
+	private function handle_list( int $acting_user_id ): array {
+		$user_id    = $acting_user_id;
 		$artist_ids = $this->get_user_artist_ids( $user_id );
 
 		if ( empty( $artist_ids ) ) {
@@ -156,20 +170,22 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 	/**
 	 * Get artist profile details.
 	 */
-	private function handle_get( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_get( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 
 		if ( is_array( $artist_id ) ) {
 			return $artist_id; // Error or disambiguation response.
 		}
 
-		return $this->rest_request( 'GET', '/artists/' . $artist_id );
+		return $this->rest_request( 'GET', '/artists/' . $artist_id, array(
+			'user_id' => $acting_user_id,
+		) );
 	}
 
 	/**
 	 * Create a new artist profile.
 	 */
-	private function handle_create( array $parameters ): array {
+	private function handle_create( array $parameters, int $acting_user_id ): array {
 		$name = $parameters['name'] ?? '';
 
 		if ( empty( $name ) ) {
@@ -192,7 +208,8 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 		}
 
 		$result = $this->rest_request( 'POST', '/artists', array(
-			'body' => $body,
+			'body'    => $body,
+			'user_id' => $acting_user_id,
 		) );
 
 		if ( $result['success'] ?? false ) {
@@ -205,8 +222,8 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 	/**
 	 * Update an existing artist profile.
 	 */
-	private function handle_update( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_update( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 
 		if ( is_array( $artist_id ) ) {
 			return $artist_id; // Error or disambiguation response.
@@ -230,7 +247,8 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 		}
 
 		$result = $this->rest_request( 'PUT', '/artists/' . $artist_id, array(
-			'body' => $body,
+			'body'    => $body,
+			'user_id' => $acting_user_id,
 		) );
 
 		if ( $result['success'] ?? false ) {
@@ -241,17 +259,18 @@ class ECRoadie_ManageArtistProfile extends ECRoadie_PlatformTool {
 	}
 
 	/**
-	 * Resolve the artist ID from parameters or auto-detect from user meta.
+	 * Resolve the artist ID from parameters or auto-detect from the acting user's meta.
 	 *
-	 * @param array $parameters Tool parameters.
+	 * @param array $parameters     Tool parameters.
+	 * @param int   $acting_user_id User to auto-detect artists for when artist_id is absent.
 	 * @return int|array<string,mixed> Artist ID on success, or error/disambiguation response array.
 	 */
-	private function resolve_artist_id( array $parameters ) {
+	private function resolve_artist_id( array $parameters, int $acting_user_id ) {
 		if ( ! empty( $parameters['artist_id'] ) ) {
 			return (int) $parameters['artist_id'];
 		}
 
-		$user_id    = get_current_user_id();
+		$user_id    = $acting_user_id;
 		$artist_ids = $this->get_user_artist_ids( $user_id );
 
 		if ( empty( $artist_ids ) ) {

--- a/inc/tools/class-manage-community.php
+++ b/inc/tools/class-manage-community.php
@@ -11,6 +11,9 @@
  *
  * @package ExtraChillRoadie\Tools
  * @since 0.1.0
+ * @since 0.8.0 Calling-user identity propagation: topics, replies, and
+ *              notifications are attributed to the calling user (or an
+ *              explicit user_id when admins override).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -35,13 +38,17 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Interact with the Extra Chill community forums. Browse forums, list and read topics, create new topics, post replies, and manage notifications. All actions run on community.extrachill.com.',
+			'description' => 'Interact with the Extra Chill community forums. Browse forums, list and read topics, create new topics, post replies, and manage notifications. Forum posts and replies are attributed to the calling user by default; admins may override via user_id. All actions run on community.extrachill.com.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
 					'action'          => array(
 						'type'        => 'string',
 						'description' => 'Action: "list_forums" (browse available forums), "list_topics" (list topics in a forum or all), "get_topic" (read a topic with replies), "create_topic" (post a new topic), "create_reply" (reply to a topic), "get_notifications" (check notifications), "mark_notifications_read" (mark all as read)',
+					),
+					'user_id'         => array(
+						'type'        => 'integer',
+						'description' => 'Target user ID for write actions (create_topic, create_reply) and notification reads. Optional. Defaults to the calling user. Admin-only override.',
 					),
 					'forum_id'        => array(
 						'type'        => 'integer',
@@ -88,21 +95,37 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
 		$action = $parameters['action'] ?? '';
 
+		// Read-only actions that don't need a user context.
+		$public_actions = array( 'list_forums', 'list_topics', 'get_topic' );
+
+		if ( in_array( $action, $public_actions, true ) ) {
+			switch ( $action ) {
+				case 'list_forums':
+					return $this->handle_list_forums();
+				case 'list_topics':
+					return $this->handle_list_topics( $parameters );
+				case 'get_topic':
+					return $this->handle_get_topic( $parameters );
+			}
+		}
+
+		// User-scoped actions: resolve and authorize.
+		$acting_user_id = $this->resolve_acting_user_id( $parameters );
+
+		$denied = $this->assert_acting_user_allowed( $acting_user_id, $parameters );
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
 		switch ( $action ) {
-			case 'list_forums':
-				return $this->handle_list_forums();
-			case 'list_topics':
-				return $this->handle_list_topics( $parameters );
-			case 'get_topic':
-				return $this->handle_get_topic( $parameters );
 			case 'create_topic':
-				return $this->handle_create_topic( $parameters );
+				return $this->handle_create_topic( $parameters, $acting_user_id );
 			case 'create_reply':
-				return $this->handle_create_reply( $parameters );
+				return $this->handle_create_reply( $parameters, $acting_user_id );
 			case 'get_notifications':
-				return $this->handle_get_notifications( $parameters );
+				return $this->handle_get_notifications( $parameters, $acting_user_id );
 			case 'mark_notifications_read':
-				return $this->handle_mark_notifications_read();
+				return $this->handle_mark_notifications_read( $acting_user_id );
 			default:
 				return $this->buildErrorResponse(
 					'Invalid action "' . $action . '". Use: list_forums, list_topics, get_topic, create_topic, create_reply, get_notifications, mark_notifications_read.',
@@ -169,7 +192,7 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 	/**
 	 * Create a new forum topic.
 	 */
-	private function handle_create_topic( array $parameters ): array {
+	private function handle_create_topic( array $parameters, int $acting_user_id ): array {
 		$forum_id = $parameters['forum_id'] ?? null;
 		$title    = $parameters['title'] ?? '';
 		$content  = $parameters['content'] ?? '';
@@ -209,11 +232,12 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 		}
 
 		$result = $this->rest_request( 'POST', '/community/topics', array(
-			'body' => array(
+			'body'    => array(
 				'forum_id' => (int) $forum_id,
 				'title'    => $title,
 				'content'  => $content,
 			),
+			'user_id' => $acting_user_id,
 		) );
 
 		if ( $result['success'] ?? false ) {
@@ -226,7 +250,7 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 	/**
 	 * Post a reply to a topic.
 	 */
-	private function handle_create_reply( array $parameters ): array {
+	private function handle_create_reply( array $parameters, int $acting_user_id ): array {
 		$topic_id = $parameters['topic_id'] ?? null;
 		$content  = $parameters['content'] ?? '';
 
@@ -247,7 +271,8 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 		}
 
 		$result = $this->rest_request( 'POST', '/community/replies', array(
-			'body' => $body,
+			'body'    => $body,
+			'user_id' => $acting_user_id,
 		) );
 
 		if ( $result['success'] ?? false ) {
@@ -258,9 +283,9 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 	}
 
 	/**
-	 * Get the current user's notifications.
+	 * Get the acting user's notifications.
 	 */
-	private function handle_get_notifications( array $parameters ): array {
+	private function handle_get_notifications( array $parameters, int $acting_user_id ): array {
 		$query = array();
 
 		if ( isset( $parameters['unread'] ) ) {
@@ -268,15 +293,18 @@ class ECRoadie_ManageCommunity extends ECRoadie_PlatformTool {
 		}
 
 		return $this->rest_request( 'GET', '/community/notifications', array(
-			'query' => $query,
+			'query'   => $query,
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
-	 * Mark all notifications as read.
+	 * Mark all notifications as read for the acting user.
 	 */
-	private function handle_mark_notifications_read(): array {
-		$result = $this->rest_request( 'POST', '/community/notifications/mark-read' );
+	private function handle_mark_notifications_read( int $acting_user_id ): array {
+		$result = $this->rest_request( 'POST', '/community/notifications/mark-read', array(
+			'user_id' => $acting_user_id,
+		) );
 
 		if ( $result['success'] ?? false ) {
 			$result['message'] = 'All notifications marked as read.';

--- a/inc/tools/class-manage-link-page.php
+++ b/inc/tools/class-manage-link-page.php
@@ -11,6 +11,9 @@
  *
  * @package ExtraChillRoadie\Tools
  * @since 0.1.0
+ * @since 0.8.0 Calling-user identity propagation: all actions act on behalf
+ *              of the calling user (or an explicit user_id when admins
+ *              override).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -35,13 +38,17 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Manage an artist\'s link page on Extra Chill. Can get the full link page, add/remove individual links, replace all links, update social links, change visual styles (colors, fonts, button shapes), and update settings (redirects, tracking pixels, subscribe mode). The artist_id is auto-resolved if the user has only one artist.',
+			'description' => 'Manage an artist\'s link page on Extra Chill. Defaults to the calling user. Admins can target another user by passing user_id. Can get the full link page, add/remove individual links, replace all links, update social links, change visual styles (colors, fonts, button shapes), and update settings (redirects, tracking pixels, subscribe mode). The artist_id is auto-resolved if the user has only one artist.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
 					'action'              => array(
 						'type'        => 'string',
 						'description' => 'Action: "get" (view link page), "add_link" (add a single link), "remove_link" (remove a link by URL or ID), "save_links" (replace all link sections), "save_socials" (replace social links), "save_styles" (update CSS variables), "save_settings" (update settings like redirects, tracking, subscribe mode)',
+					),
+					'user_id'             => array(
+						'type'        => 'integer',
+						'description' => 'Target user ID for auto-resolving artist_id. Optional. Defaults to the calling user. Admin-only override.',
 					),
 					'artist_id'           => array(
 						'type'        => 'integer',
@@ -96,23 +103,30 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$acting_user_id = $this->resolve_acting_user_id( $parameters );
+
+		$denied = $this->assert_acting_user_allowed( $acting_user_id, $parameters );
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
 		$action = $parameters['action'] ?? '';
 
 		switch ( $action ) {
 			case 'get':
-				return $this->handle_get( $parameters );
+				return $this->handle_get( $parameters, $acting_user_id );
 			case 'add_link':
-				return $this->handle_add_link( $parameters );
+				return $this->handle_add_link( $parameters, $acting_user_id );
 			case 'remove_link':
-				return $this->handle_remove_link( $parameters );
+				return $this->handle_remove_link( $parameters, $acting_user_id );
 			case 'save_links':
-				return $this->handle_save_links( $parameters );
+				return $this->handle_save_links( $parameters, $acting_user_id );
 			case 'save_socials':
-				return $this->handle_save_socials( $parameters );
+				return $this->handle_save_socials( $parameters, $acting_user_id );
 			case 'save_styles':
-				return $this->handle_save_styles( $parameters );
+				return $this->handle_save_styles( $parameters, $acting_user_id );
 			case 'save_settings':
-				return $this->handle_save_settings( $parameters );
+				return $this->handle_save_settings( $parameters, $acting_user_id );
 			default:
 				return $this->buildErrorResponse(
 					'Invalid action "' . $action . '". Use: get, add_link, remove_link, save_links, save_socials, save_styles, save_settings.',
@@ -124,13 +138,15 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 	/**
 	 * Get the full link page data.
 	 */
-	private function handle_get( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_get( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
 
-		return $this->rest_request( 'GET', '/artists/' . $artist_id . '/links' );
+		return $this->rest_request( 'GET', '/artists/' . $artist_id . '/links', array(
+			'user_id' => $acting_user_id,
+		) );
 	}
 
 	/**
@@ -139,8 +155,8 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 	 * Fetches current links, appends the new one, and saves. This convenience
 	 * action avoids making the AI do the fetch-modify-save dance.
 	 */
-	private function handle_add_link( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_add_link( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
@@ -158,7 +174,9 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		$section_title = $parameters['section'] ?? '';
 
 		// Fetch current link page data to get existing links.
-		$current = $this->rest_request( 'GET', '/artists/' . $artist_id . '/links' );
+		$current = $this->rest_request( 'GET', '/artists/' . $artist_id . '/links', array(
+			'user_id' => $acting_user_id,
+		) );
 
 		if ( ! ( $current['success'] ?? false ) ) {
 			return $current;
@@ -201,15 +219,16 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		);
 
 		return $this->rest_request( 'PUT', '/artists/' . $artist_id . '/links', array(
-			'body' => array( 'links' => $sections ),
+			'body'    => array( 'links' => $sections ),
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
 	 * Remove a link from the link page by URL or link ID.
 	 */
-	private function handle_remove_link( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_remove_link( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
@@ -225,7 +244,9 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		}
 
 		// Fetch current links.
-		$current = $this->rest_request( 'GET', '/artists/' . $artist_id . '/links' );
+		$current = $this->rest_request( 'GET', '/artists/' . $artist_id . '/links', array(
+			'user_id' => $acting_user_id,
+		) );
 
 		if ( ! ( $current['success'] ?? false ) ) {
 			return $current;
@@ -256,15 +277,16 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		}
 
 		return $this->rest_request( 'PUT', '/artists/' . $artist_id . '/links', array(
-			'body' => array( 'links' => $sections ),
+			'body'    => array( 'links' => $sections ),
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
 	 * Replace all link sections.
 	 */
-	private function handle_save_links( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_save_links( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
@@ -275,15 +297,16 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		}
 
 		return $this->rest_request( 'PUT', '/artists/' . $artist_id . '/links', array(
-			'body' => array( 'links' => $links ),
+			'body'    => array( 'links' => $links ),
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
 	 * Replace social links.
 	 */
-	private function handle_save_socials( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_save_socials( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
@@ -294,15 +317,16 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		}
 
 		return $this->rest_request( 'PUT', '/artists/' . $artist_id . '/links', array(
-			'body' => array( 'socials' => $socials ),
+			'body'    => array( 'socials' => $socials ),
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
 	 * Update CSS variables (merge with existing).
 	 */
-	private function handle_save_styles( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_save_styles( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
@@ -313,15 +337,16 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		}
 
 		return $this->rest_request( 'PUT', '/artists/' . $artist_id . '/links', array(
-			'body' => array( 'css_vars' => $css_vars ),
+			'body'    => array( 'css_vars' => $css_vars ),
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
 	 * Update link page settings.
 	 */
-	private function handle_save_settings( array $parameters ): array {
-		$artist_id = $this->resolve_artist_id( $parameters );
+	private function handle_save_settings( array $parameters, int $acting_user_id ): array {
+		$artist_id = $this->resolve_artist_id( $parameters, $acting_user_id );
 		if ( is_array( $artist_id ) ) {
 			return $artist_id;
 		}
@@ -346,22 +371,24 @@ class ECRoadie_ManageLinkPage extends ECRoadie_PlatformTool {
 		}
 
 		return $this->rest_request( 'PUT', '/artists/' . $artist_id . '/links', array(
-			'body' => $body,
+			'body'    => $body,
+			'user_id' => $acting_user_id,
 		) );
 	}
 
 	/**
-	 * Resolve the artist ID from parameters or auto-detect from user meta.
+	 * Resolve the artist ID from parameters or auto-detect from the acting user's meta.
 	 *
-	 * @param array $parameters Tool parameters.
+	 * @param array $parameters     Tool parameters.
+	 * @param int   $acting_user_id User to auto-detect artists for when artist_id is absent.
 	 * @return int|array<string,mixed> Artist ID on success, or error/disambiguation response array.
 	 */
-	private function resolve_artist_id( array $parameters ) {
+	private function resolve_artist_id( array $parameters, int $acting_user_id ) {
 		if ( ! empty( $parameters['artist_id'] ) ) {
 			return (int) $parameters['artist_id'];
 		}
 
-		$user_id    = get_current_user_id();
+		$user_id    = $acting_user_id;
 		$artist_ids = $this->get_user_artist_ids( $user_id );
 
 		if ( empty( $artist_ids ) ) {

--- a/inc/tools/class-manage-user-profile.php
+++ b/inc/tools/class-manage-user-profile.php
@@ -2,17 +2,23 @@
 /**
  * Manage User Profile Tool
  *
- * Chat tool for reading and updating the current user's profile — bio,
- * custom title, city, and profile links. Routes requests through the
- * REST API for architectural consistency with other platform tools.
+ * Chat tool for reading and updating a user's profile — bio, custom title,
+ * city, and profile links. Routes requests through the REST API for
+ * architectural consistency with other platform tools.
  *
  * User profile routes have no site affinity (extrachill-users is
  * network-activated), so requests work from any site. We use 'main'
  * as the site_key to ensure the API plugin is loaded.
  *
+ * Identity model: the tool acts on behalf of `calling_user_id` by default
+ * (the chat caller). An admin agent can target another user by passing
+ * `user_id` explicitly; non-admins attempting that get a clean permission
+ * denial.
+ *
  * @package ExtraChillRoadie\Tools
  * @since 0.1.0
  * @since 0.5.0 Refactored to use ECRoadie_PlatformTool + REST.
+ * @since 0.8.0 Calling-user identity propagation via user_id + calling_user_id.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -37,13 +43,17 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'Manage the current user\'s Extra Chill profile. Can get profile details, update bio/title/city, or replace profile links. Profile links are different from artist link pages — these are the links shown on the user\'s community profile.',
+			'description' => 'Manage a user\'s Extra Chill profile. Defaults to the calling user. Admins can target another user by passing user_id. Can get profile details, update bio/title/city, or replace profile links. Profile links are different from artist link pages — these are the links shown on the user\'s community profile.',
 			'parameters'  => array(
 				'type'       => 'object',
 				'properties' => array(
 					'action'       => array(
 						'type'        => 'string',
 						'description' => 'Action: "get" (view profile), "update" (update bio, title, or city), "update_links" (replace profile links)',
+					),
+					'user_id'      => array(
+						'type'        => 'integer',
+						'description' => 'Target user ID. Optional. Defaults to the calling user. Admin-only override — non-admins targeting another user get a permission error.',
 					),
 					'custom_title' => array(
 						'type'        => 'string',
@@ -69,15 +79,22 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 	}
 
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$acting_user_id = $this->resolve_acting_user_id( $parameters );
+
+		$denied = $this->assert_acting_user_allowed( $acting_user_id, $parameters );
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
 		$action = $parameters['action'] ?? '';
 
 		switch ( $action ) {
 			case 'get':
-				return $this->handle_get();
+				return $this->handle_get( $acting_user_id );
 			case 'update':
-				return $this->handle_update( $parameters );
+				return $this->handle_update( $parameters, $acting_user_id );
 			case 'update_links':
-				return $this->handle_update_links( $parameters );
+				return $this->handle_update_links( $parameters, $acting_user_id );
 			default:
 				return $this->buildErrorResponse(
 					'Invalid action "' . $action . '". Use: get, update, update_links.',
@@ -87,24 +104,22 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 	}
 
 	/**
-	 * Get the current user's profile.
+	 * Get the acting user's profile.
+	 *
+	 * The REST endpoint (`/users/me/profile`) reads the authenticated user
+	 * via get_current_user_id(); ec_cross_site_rest_request() switches the
+	 * user for the duration of the call when `user_id` is supplied.
 	 */
-	private function handle_get(): array {
-		if ( ! get_current_user_id() ) {
-			return $this->buildErrorResponse( 'You must be logged in.', 'manage_user_profile' );
-		}
-
-		return $this->rest_request( 'GET', '/users/me/profile' );
+	private function handle_get( int $acting_user_id ): array {
+		return $this->rest_request( 'GET', '/users/me/profile', array(
+			'user_id' => $acting_user_id,
+		) );
 	}
 
 	/**
-	 * Update the current user's profile fields.
+	 * Update the acting user's profile fields.
 	 */
-	private function handle_update( array $parameters ): array {
-		if ( ! get_current_user_id() ) {
-			return $this->buildErrorResponse( 'You must be logged in.', 'manage_user_profile' );
-		}
-
+	private function handle_update( array $parameters, int $acting_user_id ): array {
 		$body = array();
 
 		$fields = array( 'custom_title', 'bio', 'local_city' );
@@ -122,7 +137,8 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 		}
 
 		$result = $this->rest_request( 'POST', '/users/me/profile', array(
-			'body' => $body,
+			'body'    => $body,
+			'user_id' => $acting_user_id,
 		) );
 
 		if ( $result['success'] ?? false ) {
@@ -133,13 +149,9 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 	}
 
 	/**
-	 * Replace the current user's profile links.
+	 * Replace the acting user's profile links.
 	 */
-	private function handle_update_links( array $parameters ): array {
-		if ( ! get_current_user_id() ) {
-			return $this->buildErrorResponse( 'You must be logged in.', 'manage_user_profile' );
-		}
-
+	private function handle_update_links( array $parameters, int $acting_user_id ): array {
 		$links = $parameters['links'] ?? null;
 
 		if ( ! is_array( $links ) ) {
@@ -147,7 +159,8 @@ class ECRoadie_ManageUserProfile extends ECRoadie_PlatformTool {
 		}
 
 		$result = $this->rest_request( 'POST', '/users/me/links', array(
-			'body' => array( 'links' => $links ),
+			'body'    => array( 'links' => $links ),
+			'user_id' => $acting_user_id,
 		) );
 
 		if ( $result['success'] ?? false ) {

--- a/tests/_stub-agent-mode-registry.php
+++ b/tests/_stub-agent-mode-registry.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Test stub for \DataMachine\Engine\AI\AgentModeRegistry.
+ *
+ * Mirrors the production class shape just enough for smoke tests to register
+ * and read back agent modes without booting Data Machine.
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+namespace DataMachine\Engine\AI;
+
+class AgentModeRegistry {
+	public static array $registered = array();
+
+	public static function register( string $id, int $priority = 50, array $args = array() ): void {
+		self::$registered[ $id ] = array(
+			'id'          => $id,
+			'priority'    => $priority,
+			'label'       => $args['label'] ?? $id,
+			'description' => $args['description'] ?? '',
+		);
+	}
+
+	public static function get( string $id ): ?array {
+		return self::$registered[ $id ] ?? null;
+	}
+
+	public static function reset(): void {
+		self::$registered = array();
+	}
+}

--- a/tests/_stub-base-tool.php
+++ b/tests/_stub-base-tool.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Test stub for \DataMachine\Engine\AI\Tools\BaseTool.
+ *
+ * Implements the minimal surface ECRoadie_PlatformTool depends on:
+ *   - registerTool()             — recorded into $GLOBALS['ec_roadie_test_registered_tools'].
+ *   - buildErrorResponse()       — standardized error array.
+ *   - buildDiagnosticErrorResponse() — error array with diagnostic/remediation.
+ *   - classifyErrorType()        — keyword-based classification.
+ *
+ * Tests can read $GLOBALS['ec_roadie_test_registered_tools'] to confirm
+ * registration happened, or just exercise tool methods directly to verify
+ * the calling_user_id contract.
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+namespace DataMachine\Engine\AI\Tools;
+
+abstract class BaseTool {
+	protected bool $async = false;
+
+	protected function registerTool( string $toolName, $toolDefinition, array $modes = array(), array $meta = array() ): void {
+		$GLOBALS['ec_roadie_test_registered_tools'][ $toolName ] = array(
+			'definition' => $toolDefinition,
+			'modes'      => $modes,
+			'meta'       => $meta,
+		);
+	}
+
+	protected function buildErrorResponse( string $error, string $tool_name ): array {
+		return array(
+			'success'    => false,
+			'error'      => $error,
+			'error_type' => $this->classifyErrorType( $error ),
+			'tool_name'  => $tool_name,
+		);
+	}
+
+	protected function buildDiagnosticErrorResponse(
+		string $error,
+		string $error_type,
+		string $tool_name,
+		array $diagnostic = array(),
+		array $remediation = array()
+	): array {
+		$response = array(
+			'success'    => false,
+			'error'      => $error,
+			'error_type' => $error_type,
+			'tool_name'  => $tool_name,
+		);
+		if ( ! empty( $diagnostic ) ) {
+			$response['diagnostic'] = $diagnostic;
+		}
+		if ( ! empty( $remediation ) ) {
+			$response['remediation'] = $remediation;
+		}
+		return $response;
+	}
+
+	protected function classifyErrorType( string $error ): string {
+		$lower = strtolower( $error );
+		if ( str_contains( $lower, 'not found' ) || str_contains( $lower, 'does not exist' ) ) {
+			return 'not_found';
+		}
+		if ( str_contains( $lower, 'required' ) || str_contains( $lower, 'invalid' ) ) {
+			return 'validation';
+		}
+		if ( str_contains( $lower, 'permission' ) || str_contains( $lower, 'denied' ) || str_contains( $lower, 'unauthorized' ) ) {
+			return 'permission';
+		}
+		return 'system';
+	}
+}

--- a/tests/_stub-wp-and-rest.php
+++ b/tests/_stub-wp-and-rest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Test stubs for WordPress + cross-site REST primitives.
+ *
+ * Reset between tests via ec_roadie_test_reset(). Records every
+ * ec_cross_site_rest_request() invocation into
+ * $GLOBALS['ec_roadie_test_rest_calls'] so smoke tests can assert that the
+ * correct user_id reached the cross-site helper.
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+function ec_roadie_test_reset(): void {
+	$GLOBALS['ec_roadie_test_current_user']    = 0;
+	$GLOBALS['ec_roadie_test_user_caps']       = array();
+	$GLOBALS['ec_roadie_test_rest_calls']      = array();
+	$GLOBALS['ec_roadie_test_registered_tools'] = $GLOBALS['ec_roadie_test_registered_tools'] ?? array();
+	$GLOBALS['ec_roadie_test_rest_response']   = array( 'ok' => true );
+}
+
+ec_roadie_test_reset();
+
+function get_current_user_id(): int {
+	return (int) ( $GLOBALS['ec_roadie_test_current_user'] ?? 0 );
+}
+
+function ec_roadie_test_login_as( int $user_id ): void {
+	$GLOBALS['ec_roadie_test_current_user'] = $user_id;
+}
+
+function ec_roadie_test_grant_cap( int $user_id, string $cap ): void {
+	$GLOBALS['ec_roadie_test_user_caps'][ $user_id ][ $cap ] = true;
+}
+
+function user_can( $user, string $cap ): bool {
+	$user_id = is_object( $user ) ? (int) ( $user->ID ?? 0 ) : (int) $user;
+	return ! empty( $GLOBALS['ec_roadie_test_user_caps'][ $user_id ][ $cap ] );
+}
+
+function current_user_can( string $cap ): bool {
+	return user_can( get_current_user_id(), $cap );
+}
+
+function wp_set_current_user( int $user_id ): void {
+	$GLOBALS['ec_roadie_test_current_user'] = $user_id;
+}
+
+function get_user_meta( int $user_id, string $key, bool $single = true ) {
+	unset( $single );
+	return $GLOBALS['ec_roadie_test_user_meta'][ $user_id ][ $key ] ?? '';
+}
+
+function ec_roadie_test_set_user_meta( int $user_id, string $key, $value ): void {
+	$GLOBALS['ec_roadie_test_user_meta'][ $user_id ][ $key ] = $value;
+}
+
+function is_wp_error( $thing ): bool {
+	return $thing instanceof WP_Error;
+}
+
+class WP_Error {
+	public string $code;
+	public string $message;
+	public function __construct( string $code = '', string $message = '' ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+	public function get_error_message(): string {
+		return $this->message;
+	}
+}
+
+function sprintf_safe( string $format, ...$args ): string {
+	return vsprintf( $format, $args );
+}
+
+function ec_get_blog_id( string $key ): ?int {
+	$map = array( 'main' => 1, 'community' => 2, 'artist' => 3 );
+	return $map[ $key ] ?? null;
+}
+
+function switch_to_blog( int $blog_id ): void {
+	$GLOBALS['ec_roadie_test_blog'] = $blog_id;
+}
+
+function restore_current_blog(): void {
+	$GLOBALS['ec_roadie_test_blog'] = 1;
+}
+
+function get_post( int $id ) {
+	return $GLOBALS['ec_roadie_test_posts'][ $id ] ?? null;
+}
+
+/**
+ * Stub of ec_cross_site_rest_request: records the call shape, optionally
+ * simulates the user-context switch the real helper performs, and returns
+ * whatever the test sets in $GLOBALS['ec_roadie_test_rest_response'].
+ */
+function ec_cross_site_rest_request( string $site_key, string $method, string $path, array $args = array() ) {
+	$entry = array(
+		'site_key' => $site_key,
+		'method'   => $method,
+		'path'     => $path,
+		'args'     => $args,
+		// Snapshot the effective user BEFORE the helper would switch context.
+		// In real life ec_cross_site_rest_request wraps wp_set_current_user
+		// in a try/finally; recording the requested user_id here is what tests
+		// actually want to assert against.
+		'effective_user' => isset( $args['user_id'] ) ? (int) $args['user_id'] : get_current_user_id(),
+	);
+	$GLOBALS['ec_roadie_test_rest_calls'][] = $entry;
+
+	$response = $GLOBALS['ec_roadie_test_rest_response'];
+	if ( $response instanceof WP_Error ) {
+		return $response;
+	}
+	return $response;
+}

--- a/tests/agent-mode-registration-smoke.php
+++ b/tests/agent-mode-registration-smoke.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Smoke test: roadie agent mode registration.
+ *
+ * Verifies that loading inc/agent-mode/register.php registers the `roadie`
+ * mode with the AgentModeRegistry (priority 45, label "Extra Chill Platform")
+ * and that the datamachine_agent_mode_roadie filter is wired and emits a
+ * non-empty guidance string covering the key contract points.
+ *
+ * Run with: php tests/agent-mode-registration-smoke.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Stub the registry class FIRST — namespace declarations cannot follow
+// procedural code in the same file.
+require_once __DIR__ . '/_stub-agent-mode-registry.php';
+
+$GLOBALS['ec_roadie_test_actions'] = array();
+$GLOBALS['ec_roadie_test_filters'] = array();
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['ec_roadie_test_actions'][ $hook ][] = $callback;
+}
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['ec_roadie_test_filters'][ $hook ][] = $callback;
+}
+
+function do_action( string $hook, ...$args ): void {
+	foreach ( $GLOBALS['ec_roadie_test_actions'][ $hook ] ?? array() as $callback ) {
+		$callback( ...$args );
+	}
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	foreach ( $GLOBALS['ec_roadie_test_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+
+	return $value;
+}
+
+function __( $text, $domain = null ): string {
+	unset( $domain );
+	return (string) $text;
+}
+
+function ec_roadie_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/agent-mode/register.php';
+
+// Trigger the action so registration runs.
+do_action( 'datamachine_agent_modes' );
+
+$mode = \DataMachine\Engine\AI\AgentModeRegistry::get( 'roadie' );
+
+ec_roadie_smoke_assert( is_array( $mode ), 'roadie mode should be registered with AgentModeRegistry.' );
+ec_roadie_smoke_assert( 'roadie' === ( $mode['id'] ?? '' ), 'roadie mode id should be "roadie".' );
+ec_roadie_smoke_assert( 45 === ( $mode['priority'] ?? 0 ), 'roadie mode priority should be 45 (after editor mode at 40).' );
+ec_roadie_smoke_assert( 'Extra Chill Platform' === ( $mode['label'] ?? '' ), 'roadie mode label should be "Extra Chill Platform".' );
+ec_roadie_smoke_assert( '' !== trim( $mode['description'] ?? '' ), 'roadie mode description should be non-empty.' );
+
+// Invoke the directive filter with a payload carrying a calling user — guidance
+// should contain the user-scoped identity line.
+$guidance_with_caller = apply_filters( 'datamachine_agent_mode_roadie', '', array( 'calling_user_id' => 38 ) );
+ec_roadie_smoke_assert( is_string( $guidance_with_caller ) && '' !== $guidance_with_caller, 'datamachine_agent_mode_roadie filter should return non-empty guidance.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'user #38' ), 'Guidance should template the calling user ID when present.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Network Topology' ), 'Guidance should cover network topology.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'manage_artist_profile' ), 'Guidance should reference manage_artist_profile tool.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'manage_link_page' ), 'Guidance should reference manage_link_page tool.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'manage_user_profile' ), 'Guidance should reference manage_user_profile tool.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'manage_community' ), 'Guidance should reference manage_community tool.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Calling-User Identity Contract' ), 'Guidance should document the calling-user identity contract.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Editorial Voice' ), 'Guidance should document editorial voice.' );
+ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Operating Mode' ), 'Guidance should document operating mode (propose-then-act for writes).' );
+
+// Without a caller, guidance should explain that user-scoped writes have no default.
+$guidance_no_caller = apply_filters( 'datamachine_agent_mode_roadie', '', array() );
+ec_roadie_smoke_assert( str_contains( $guidance_no_caller, 'no human caller' ), 'Guidance should explain the no-caller case for system tasks.' );
+
+// Filter should compose with prior content rather than replace it.
+$composed = apply_filters( 'datamachine_agent_mode_roadie', "# Existing\nPrior directive content.", array() );
+ec_roadie_smoke_assert( str_starts_with( $composed, "# Existing\nPrior directive content." ), 'Filter should append to existing directive content, not overwrite it.' );
+
+echo "Roadie agent mode registration smoke passed (14 assertions).\n";

--- a/tests/calling-user-identity-smoke.php
+++ b/tests/calling-user-identity-smoke.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Smoke test: calling-user identity propagation through Roadie tools.
+ *
+ * Verifies that manage_user_profile defaults to acting on calling_user_id
+ * when no explicit user_id is provided, and that the resolved user reaches
+ * the cross-site REST helper unchanged.
+ *
+ * Run with: php tests/calling-user-identity-smoke.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/_stub-base-tool.php';
+require_once __DIR__ . '/_stub-wp-and-rest.php';
+
+require_once dirname( __DIR__ ) . '/inc/tools/class-ec-platform-tool.php';
+require_once dirname( __DIR__ ) . '/inc/tools/class-manage-user-profile.php';
+
+function ec_roadie_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+// --- Scenario 1: calling_user_id present, no explicit user_id ---
+// Tool should default to the calling user. Cross-site REST gets user_id=38.
+ec_roadie_test_reset();
+ec_roadie_test_login_as( 38 );
+$tool = new ECRoadie_ManageUserProfile();
+
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'update',
+		'bio'             => 'New bio from chat session.',
+		'calling_user_id' => 38, // What the DM loop merges into $parameters.
+	)
+);
+
+ec_roadie_smoke_assert( ( $result['success'] ?? false ) === true, 'Update should succeed when calling user acts on self.' );
+
+$calls = $GLOBALS['ec_roadie_test_rest_calls'];
+ec_roadie_smoke_assert( 1 === count( $calls ), 'Exactly one REST call should be made.' );
+ec_roadie_smoke_assert( '/users/me/profile' === $calls[0]['path'], 'Call should target /users/me/profile.' );
+ec_roadie_smoke_assert( 38 === $calls[0]['effective_user'], 'REST call should authenticate as calling user #38, not site admin.' );
+ec_roadie_smoke_assert( 38 === ( $calls[0]['args']['user_id'] ?? 0 ), 'user_id arg must be forwarded into ec_cross_site_rest_request.' );
+
+// --- Scenario 2: admin caller targets another user via explicit user_id ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( 1 );
+ec_roadie_test_grant_cap( 1, 'manage_options' );
+
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'update',
+		'bio'             => 'Admin updates another user.',
+		'user_id'         => 99,
+		'calling_user_id' => 1,
+	)
+);
+
+ec_roadie_smoke_assert( ( $result['success'] ?? false ) === true, 'Admin acting on another user should be allowed.' );
+
+$calls = $GLOBALS['ec_roadie_test_rest_calls'];
+ec_roadie_smoke_assert( 1 === count( $calls ), 'Exactly one REST call should be made.' );
+ec_roadie_smoke_assert( 99 === ( $calls[0]['args']['user_id'] ?? 0 ), 'Explicit user_id override should reach the cross-site helper.' );
+
+// --- Scenario 3: calling user falls back to current user when payload is silent ---
+// REST-initiated invocation with no chat loop — should still resolve to current user.
+ec_roadie_test_reset();
+ec_roadie_test_login_as( 42 );
+
+$result = $tool->handle_tool_call(
+	array(
+		'action' => 'get',
+		// No calling_user_id and no user_id — REST/CLI context.
+	)
+);
+
+ec_roadie_smoke_assert( ( $result['success'] ?? false ) === true, 'Get should succeed with current-user fallback.' );
+
+$calls = $GLOBALS['ec_roadie_test_rest_calls'];
+ec_roadie_smoke_assert( 42 === ( $calls[0]['args']['user_id'] ?? 0 ), 'Fallback to current user (#42) should reach the cross-site helper.' );
+
+// --- Scenario 4: no user at all → clean denial, no REST call ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( 0 );
+
+$result = $tool->handle_tool_call(
+	array(
+		'action' => 'update',
+		'bio'    => 'Anonymous attempt.',
+	)
+);
+
+ec_roadie_smoke_assert( false === ( $result['success'] ?? true ), 'Anonymous caller should be denied.' );
+ec_roadie_smoke_assert( 0 === count( $GLOBALS['ec_roadie_test_rest_calls'] ), 'Denied call must not reach REST.' );
+ec_roadie_smoke_assert( str_contains( $result['error'] ?? '', 'No user context' ), 'Denial message should explain the missing user context.' );
+
+echo "Roadie calling-user identity smoke passed (12 assertions).\n";

--- a/tests/calling-user-permission-denial-smoke.php
+++ b/tests/calling-user-permission-denial-smoke.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Smoke test: non-admin caller trying to act on another user's behalf
+ * gets a clean permission denial (no stack trace, no silent success).
+ *
+ * Exercises every tool that accepts user_id (artist profile, link page,
+ * user profile, community) to confirm the assert_acting_user_allowed()
+ * guard in ECRoadie_PlatformTool refuses cross-user impersonation by
+ * non-admins.
+ *
+ * Run with: php tests/calling-user-permission-denial-smoke.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/_stub-base-tool.php';
+require_once __DIR__ . '/_stub-wp-and-rest.php';
+
+require_once dirname( __DIR__ ) . '/inc/tools/class-ec-platform-tool.php';
+require_once dirname( __DIR__ ) . '/inc/tools/class-manage-artist-profile.php';
+require_once dirname( __DIR__ ) . '/inc/tools/class-manage-link-page.php';
+require_once dirname( __DIR__ ) . '/inc/tools/class-manage-user-profile.php';
+require_once dirname( __DIR__ ) . '/inc/tools/class-manage-community.php';
+
+function ec_roadie_smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+/**
+ * Drive a tool call, assert that it returned a clean permission denial,
+ * and confirm no cross-site REST call was made.
+ */
+function ec_roadie_assert_denied( array $result, string $context ): void {
+	ec_roadie_smoke_assert( is_array( $result ), $context . ': result must be an array (not a stack trace).' );
+	ec_roadie_smoke_assert( false === ( $result['success'] ?? true ), $context . ': result should signal failure.' );
+	ec_roadie_smoke_assert( isset( $result['error'] ), $context . ': result must include an error message.' );
+	ec_roadie_smoke_assert( 'permission' === ( $result['error_type'] ?? '' ), $context . ': error_type should be permission.' );
+	ec_roadie_smoke_assert(
+		str_contains( strtolower( $result['error'] ), 'permission denied' ),
+		$context . ': error message should say "Permission denied".'
+	);
+	ec_roadie_smoke_assert(
+		0 === count( $GLOBALS['ec_roadie_test_rest_calls'] ),
+		$context . ': denied call must not reach the cross-site REST helper.'
+	);
+}
+
+// Non-admin caller (#38) tries to act on user #99 across every tool.
+$non_admin = 38;
+$victim    = 99;
+
+// --- manage_user_profile ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $non_admin );
+
+$tool   = new ECRoadie_ManageUserProfile();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'update',
+		'bio'             => 'Impersonation attempt.',
+		'user_id'         => $victim,
+		'calling_user_id' => $non_admin,
+	)
+);
+ec_roadie_assert_denied( $result, 'manage_user_profile non-admin impersonation' );
+
+// --- manage_artist_profile ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $non_admin );
+
+$tool   = new ECRoadie_ManageArtistProfile();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'create',
+		'name'            => 'Hijacked Artist',
+		'user_id'         => $victim,
+		'calling_user_id' => $non_admin,
+	)
+);
+ec_roadie_assert_denied( $result, 'manage_artist_profile non-admin impersonation' );
+
+// --- manage_link_page ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $non_admin );
+
+$tool   = new ECRoadie_ManageLinkPage();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'get',
+		'artist_id'       => 123,
+		'user_id'         => $victim,
+		'calling_user_id' => $non_admin,
+	)
+);
+ec_roadie_assert_denied( $result, 'manage_link_page non-admin impersonation' );
+
+// --- manage_community ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $non_admin );
+
+$tool   = new ECRoadie_ManageCommunity();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'create_reply',
+		'topic_id'        => 456,
+		'content'         => 'Posted as someone else.',
+		'user_id'         => $victim,
+		'calling_user_id' => $non_admin,
+	)
+);
+ec_roadie_assert_denied( $result, 'manage_community non-admin impersonation' );
+
+// --- Sanity: admin caller IS allowed to act on another user ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( 1 );
+ec_roadie_test_grant_cap( 1, 'manage_options' );
+
+$tool   = new ECRoadie_ManageUserProfile();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'update',
+		'bio'             => 'Legitimate admin edit.',
+		'user_id'         => $victim,
+		'calling_user_id' => 1,
+	)
+);
+ec_roadie_smoke_assert( ( $result['success'] ?? false ) === true, 'Admin should be allowed to act on another user.' );
+
+// --- Sanity: read-only community actions don't require user context ---
+ec_roadie_test_reset();
+ec_roadie_test_login_as( 0 );
+
+$tool   = new ECRoadie_ManageCommunity();
+$result = $tool->handle_tool_call( array( 'action' => 'list_forums' ) );
+ec_roadie_smoke_assert(
+	( $result['success'] ?? false ) === true,
+	'list_forums should succeed without a user context (public read).'
+);
+
+echo "Roadie calling-user permission denial smoke passed (28 assertions).\n";


### PR DESCRIPTION
## Summary

Lands issue #8: registers the `roadie` execution mode with Data Machine's `AgentModeRegistry`, injects EC platform context into the AI prompt via the `datamachine_agent_mode_roadie` filter, and propagates `calling_user_id` through all four existing Roadie chat tools.

Closes #8.

## Pattern reference

Followed the **data-machine-editor** pattern verbatim (the issue called it out as the reference):

- `data-machine-editor.php:56-61` — `add_action( 'datamachine_agent_modes', ... )` registration at priority 40
- `data-machine-editor.php:64` — `add_filter( 'datamachine_agent_mode_editor', ... )` directive callback
- `data-machine-editor.php:85-114` — guidance string returned by the filter

Roadie registers at priority **45** (vs editor's 40) so editor mode wins when both are active in the same invocation — they never should be, but the explicit ordering documents intent.

## What landed

### 1. Agent mode registration

- New file: `inc/agent-mode/register.php`
- `add_action( 'datamachine_agent_modes', ... )` registers `roadie` mode with label "Extra Chill Platform" and a description focused on the EC platform tool surface.
- `add_filter( 'datamachine_agent_mode_roadie', 'extrachill_roadie_mode_guidance', 10, 2 )` returns a focused guidance string covering:
  - **Network topology** — the 9 EC subdomains and what each is for
  - **Available tool domains** — what each of the 4 tools does and when to reach for it
  - **Calling-user identity contract** — templated with the actual calling user ID when present, or "no human caller" guidance when the value is 0
  - **Cross-site conventions** — identity is network-wide, content is per-site, tools handle blog switching internally
  - **Editorial voice** — music-forward, grassroots, not corporate (kept agent-agnostic — the same prompt composes cleanly with any agent's SOUL.md)
  - **Operating mode** — propose-then-act for content changes, act immediately for lookups, cite sources
- Filter callback composes with prior content (`return $content . "\n\n" . $guidance;`) so other extensions can stack on top.

### 2. ECRoadie_PlatformTool helpers

Added to the shared base class so the calling-user pattern is trivial to apply to future tools:

- `get_calling_user_id( $parameters )` — reads `$parameters['calling_user_id']`. Prefers the canonical `datamachine_get_calling_user_id()` core helper when available so we stay in sync with future contract changes.
- `resolve_acting_user_id( $parameters )` — priority order: explicit `user_id` input → `calling_user_id` → `get_current_user_id()`.
- `assert_acting_user_allowed( $acting, $parameters )` — returns a standardized permission-denied response (or `null` when allowed). Non-admin callers acting on another user are refused before any REST call.
- `rest_request()` docblock updated to document the `user_id` arg, which the underlying `ec_cross_site_rest_request()` already supported (wraps `wp_set_current_user()` in try/finally — no in-tool context-juggling required).

### 3. Tool refactor

All four tools now:

1. Accept an optional `user_id` input parameter (admin-only override).
2. Resolve the acting user once at the top of `handle_tool_call()`.
3. Assert permission via `assert_acting_user_allowed()` — denied calls return cleanly before reaching REST.
4. Thread `'user_id' => $acting_user_id` into every cross-site REST call.
5. Replace direct `get_current_user_id()` calls with `$acting_user_id` for user-meta lookups (manage_artist_profile + manage_link_page).

`manage_community` short-circuits the resolve/assert pair for public read actions (`list_forums`, `list_topics`, `get_topic`) so anonymous browsing still works.

### 4. No Data Machine core changes

The issue flagged that `BaseTool` might need a small DM core change to surface `calling_user_id` to subclasses. **It does not.**

The flow already works:

```
ChatOrchestrator builds loop_context with calling_user_id
  ↓
datamachine_run_conversation passes it as part of $loop_payload
  ↓
ToolExecutor::executeTool receives $tool_payload (= $loop_payload + run_artifacts)
  ↓
ToolParameters::buildParameters MERGES the payload INTO $parameters
  ↓
handle_tool_call( $parameters, $tool_def ) — $parameters['calling_user_id'] is present
```

Verified by reading `inc/Engine/AI/Tools/ToolParameters.php:25-40` and `conversation-loop.php:575-585`.

## Acceptance criteria

- [x] **Depends on data-machine#2081** — verified: `datamachine_get_calling_user_id()` exists at `conversation-loop.php:1176` and the chat orchestrator sets `calling_user_id` on the loop context at `ChatOrchestrator.php:757-764`.
- [x] **`Roadie` mode registered via `AgentModeRegistry`** — `inc/agent-mode/register.php:39-54`. Confirmed in `tests/agent-mode-registration-smoke.php`.
- [x] **`datamachine_agent_mode_roadie` filter implemented with EC platform context** — `inc/agent-mode/register.php:74-148`. Confirmed in `tests/agent-mode-registration-smoke.php` (14 assertions covering topology, tool references, identity contract, voice, operating mode, composition with prior content).
- [x] **All four tools accept and respect `calling_user_id`** — every `handle_tool_call()` calls `resolve_acting_user_id( $parameters )` first. Confirmed in `tests/calling-user-identity-smoke.php` (scenario 1: calling user reaches the cross-site helper via `args['user_id']`).
- [x] **Tools support explicit `user_id` override with admin permission check** — `user_id` is in every tool's parameter schema; `assert_acting_user_allowed()` enforces `manage_options`. Confirmed in `tests/calling-user-permission-denial-smoke.php` (28 assertions: every tool refuses non-admin impersonation, admin override is allowed, no REST call is made on denial).
- [x] **Smoke test: chat caller invokes `manage_user_profile` → profile updated for caller, not site admin** — `tests/calling-user-identity-smoke.php` scenario 1 asserts the REST call carries `user_id=38` (the calling user), not `user_id=1` (site admin).
- [x] **Smoke test: non-admin attempting cross-user action → clean permission denial, not stack trace** — `tests/calling-user-permission-denial-smoke.php` exercises all four tools; every response is `success: false`, `error_type: permission`, and zero REST calls are recorded.
- [x] **Documentation snippet** — `README.md` gained sections for the **Agent Mode** registration, **Calling-User Identity Contract**, and a step-by-step **Adding a New Roadie Tool** procedure. The filters table also lists `datamachine_agent_modes` and `datamachine_agent_mode_roadie`.

## Tests

```
$ php tests/agent-mode-registration-smoke.php
Roadie agent mode registration smoke passed (14 assertions).

$ php tests/calling-user-identity-smoke.php
Roadie calling-user identity smoke passed (12 assertions).

$ php tests/calling-user-permission-denial-smoke.php
Roadie calling-user permission denial smoke passed (28 assertions).

$ php tests/frontend-chat-branding-smoke.php
Roadie frontend chat branding smoke passed (3 assertions).

$ for f in tests/contribute-code-*.php; do php "$f"; done
contribute-code capabilities smoke passed.
contribute-code inherit-resolver smoke passed.
contribute-code recipe-builder smoke passed.
contribute-code subsite-context smoke passed.
contribute-code tool-registration smoke passed.
```

All existing smoke tests remain green.

## Out of scope (per issue #8)

- Drive / Notion / external-provider tools — separate Roadie tools after this PR establishes the pattern.
- Per-user OAuth UI — `extrachill-users#44`.
- Cross-agent permission audit — follow-up if real abuse scenarios emerge.