### PR TITLE
refactor(apply-code-change): use GitHubCredentialResolver for git push + gh pr create

### DIFF
--- a/docs/contribute-code.md
+++ b/docs/contribute-code.md
@@ -43,23 +43,31 @@ wp --allow-root --path=/var/www/extrachill.com network meta update 1 wp_codebox_
 
 Roadie does **not** include the agent stack in its own recipe — wp-codebox handles it via these network options. Including them would double-mount.
 
-### 3. GitHub token (host-only, for apply-back)
+### 3. GitHub credentials (host-only, for apply-back)
 
-The `apply_code_change` tool shells out to `git push` and `gh pr create` on the host. Both pick up `GITHUB_TOKEN` from the PHP process environment. **The token never enters the sandbox** — sandboxes don't push.
+The `apply_code_change` tool shells out to `git push` and `gh pr create` on the host. GitHub auth is resolved per-repo via the Data Machine credential profile system (`DataMachineCode\Support\GitHubCredentialResolver`), which supports both classic PATs and GitHub App installation tokens. **The token never enters the sandbox** — sandboxes don't push.
 
-In `wp-config.php`:
+For each shell-out, apply-back:
 
-```php
-putenv( 'GITHUB_TOKEN=' . 'ghp_xxxxxxxxxxxx' );
+1. Calls `GitHubCredentialResolver::resolve( [ 'repo' => $repo ] )` to mint a fresh credential scoped to the target repo (picks the matching profile by `allowed_repos`, falls back to the default profile).
+2. Threads the resulting token into the shell command via per-command env: `git -c http.extraheader="Authorization: Bearer <token>" push ...` and `GH_TOKEN=<token> gh pr create ...`.
+3. Never `putenv()`s the token globally — there is no leakage into the PHP process env, into the sandbox, or into any subprocess that wasn't explicitly built with the credential.
+
+When the configured profile uses App mode, the resolver mints a short-lived installation token (`ghs_...`, ~1 hour TTL) on each call. PRs opened by apply-back are then authored by the GitHub App's bot identity (e.g. `homeboy-ci[bot]`), not by a personal account.
+
+#### Verify configuration
+
+```bash
+wp --allow-root --path=/var/www/extrachill.com datamachine-code github status
 ```
 
-Token needs `repo` scope (classic) or fine-grained equivalent (contents read/write + pull requests read/write) on every Extra-Chill repo the flow might target. To use a different env var name:
+This prints the default profile id, the configured mode, and a configured/not-configured summary per profile. Both `apply_code_change` and `propose_code_change` fail fast with an explicit error if `GitHubCredentialResolver::isConfigured()` is false.
 
-```php
-add_filter( 'extrachill_roadie_apply_github_token_env', fn() => 'EC_BOT_GH_TOKEN' );
-```
+#### Configure profiles
 
-The tool fails with a clear error if the env var isn't set or is empty.
+Profiles live in the `github_credential_profiles` setting, with `github_default_profile_id` pointing at the fallback. Write via the `datamachine/update-settings` ability (REST, CLI, or chat). The resolver also reads the legacy single-credential keys (`github_pat`, `github_auth_mode`, `github_app_*`) when the new structure is empty, so existing installs keep working until operators migrate.
+
+Tokens never need to be exported in the PHP-FPM environment, in `wp-config.php`, or anywhere else outside the credential profile store.
 
 ### 4. OpenAI credentials (inheritance, bridged from options to env)
 
@@ -161,7 +169,8 @@ If a contributor describes a change to a plugin that isn't in the map, the recip
 │    3. git apply                                                     │
 │    4. git commit -m "fix(<slug>): <summary>"                        │
 │    5. git push origin <branch>                                      │
-│    6. gh pr create (uses GITHUB_TOKEN from host env)                │
+│    6. gh pr create (GH_TOKEN from per-command env, freshly minted   │
+│         by GitHubCredentialResolver — never global putenv)          │
 │  Returns pr_urls back to chat                                       │
 └────────────────────────────────────────────────────────────────────┘
 ```
@@ -174,7 +183,7 @@ Sandbox boundary: nothing crosses except (1) mounted host files into VFS at boot
 # 1. Verify env is set up
 wp --allow-root --path=/var/www/extrachill.com network meta get 1 wp_codebox_bin
 wp --allow-root --path=/var/www/extrachill.com network meta get 1 wp_codebox_component_paths
-echo "GITHUB_TOKEN=${GITHUB_TOKEN:+set}"
+wp --allow-root --path=/var/www/extrachill.com datamachine-code github status
 
 # 2. Trigger propose tool
 wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com eval '
@@ -202,7 +211,7 @@ echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
 
 - **Preview URL TTL:** controlled by `preview_hold_seconds` (default 900). Override via `extrachill_roadie_preview_hold_seconds` filter. Max 3600.
 - **Worktree convention:** apply-back creates worktrees as `<repo>@roadie-<slug>-<short-artifact-id>`. These are tracked in the DMC workspace registry and can be cleaned up via `wp datamachine-code workspace worktree mark-cleanup-eligible <handle>` after PR merge.
-- **Commit identity:** all commits authored by `Extra Chill Bot <bot@extrachill.com>` using the host `GITHUB_TOKEN`. Override via `extrachill_roadie_apply_commit_name` / `extrachill_roadie_apply_commit_email` filters.
+- **Commit identity:** all commits authored by `Extra Chill Bot <bot@extrachill.com>` (configured via `extrachill_roadie_apply_commit_name` / `extrachill_roadie_apply_commit_email` filters). The PR author on GitHub is whoever owns the resolved credential profile — when using the default `homeboy-ci` App profile, PRs are authored by `homeboy-ci[bot]`.
 - **No release / no deploy:** apply-back opens a PR; merge and release stay manual on GitHub. There is no path from chat to production deploy.
 
 ## Upstream dependencies & open work

--- a/inc/contribute-code/capabilities.php
+++ b/inc/contribute-code/capabilities.php
@@ -84,41 +84,14 @@ function extrachill_roadie_grant_propose_code_cap( array $allcaps, array $caps, 
 }
 add_filter( 'user_has_cap', 'extrachill_roadie_grant_propose_code_cap', 10, 4 );
 
-/**
- * Env var name holding the GitHub token used by the apply-back tool.
+/*
+ * Apply-back GitHub credentials are no longer sourced from the PHP process
+ * environment. The previous `extrachill_roadie_apply_github_token_env_name()`
+ * + `_present()` helpers (and the `extrachill_roadie_apply_github_token_env`
+ * filter) were removed when apply-back switched to
+ * `DataMachineCode\Support\GitHubCredentialResolver`. Tokens are now minted
+ * per-repo via the configured credential profile and threaded into each
+ * shell-out via per-command env. Verify configuration with:
  *
- * Apply-back shells out to `gh pr create` (and underlying `git push`) on the
- * host. Both pick up `GITHUB_TOKEN` from the process environment. The token
- * never crosses into the sandbox — sandboxes don't push.
- *
- * Override the env var name via the `extrachill_roadie_apply_github_token_env`
- * filter if your host exports the token under a different name.
- *
- * @since 0.7.0
- * @return string
+ *   wp --allow-root --path=/var/www/extrachill.com datamachine-code github status
  */
-function extrachill_roadie_apply_github_token_env_name(): string {
-	/**
-	 * Filter the env var name holding the GitHub token for apply-back.
-	 *
-	 * @since 0.7.0
-	 *
-	 * @param string $default Default env var name.
-	 */
-	return (string) apply_filters( 'extrachill_roadie_apply_github_token_env', 'GITHUB_TOKEN' );
-}
-
-/**
- * Check whether the apply-back GitHub token env var is present and non-empty.
- *
- * @since 0.7.0
- * @return bool
- */
-function extrachill_roadie_apply_github_token_present(): bool {
-	$name = extrachill_roadie_apply_github_token_env_name();
-	if ( '' === $name ) {
-		return false;
-	}
-	$value = getenv( $name );
-	return is_string( $value ) && '' !== trim( $value );
-}

--- a/inc/tools/class-apply-code-change.php
+++ b/inc/tools/class-apply-code-change.php
@@ -19,7 +19,9 @@
  *      multiple components).
  *
  * The sandbox never runs git. All git operations live here, on the host.
- * GITHUB_TOKEN is read from the host PHP process env.
+ * GitHub credentials are minted per-repo via DataMachineCode\Support\GitHubCredentialResolver
+ * (App-mode installation tokens or PAT, per the configured credential profile)
+ * and threaded into each shell-out via per-command env, never via global putenv().
  *
  * @package ExtraChillRoadie\Tools
  * @since 0.7.0
@@ -30,6 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineCode\Support\GitHubCredentialResolver;
 
 class ECRoadie_ApplyCodeChange extends BaseTool {
 
@@ -89,10 +92,9 @@ class ECRoadie_ApplyCodeChange extends BaseTool {
 			return $this->buildErrorResponse( 'artifact_id is required.', $this->tool_slug );
 		}
 
-		if ( ! extrachill_roadie_apply_github_token_present() ) {
-			$env = extrachill_roadie_apply_github_token_env_name();
+		if ( ! $this->resolver_is_configured() ) {
 			return $this->buildErrorResponse(
-				sprintf( 'GitHub token is not configured. The env var "%s" must be set in the WordPress PHP process for apply-back to push and open PRs. Set it via putenv() in wp-config.php (or a .env loader).', $env ),
+				'GitHub credentials are not configured. Apply-back resolves a token per repo via the Data Machine credential profile system. Verify with `wp --allow-root --path=/var/www/extrachill.com datamachine-code github status`, and configure via the `datamachine/update-settings` ability with `github_credential_profiles` + `github_default_profile_id`.',
 				$this->tool_slug
 			);
 		}
@@ -290,6 +292,34 @@ class ECRoadie_ApplyCodeChange extends BaseTool {
 			);
 		}
 
+		// Resolve GitHub credentials once per repo. App-mode installation
+		// tokens are valid for ~1 hour, which comfortably covers push + PR
+		// creation. The token is threaded into shell-outs via per-command
+		// env (http.extraheader for git, GH_TOKEN= prefix for gh) — never
+		// putenv'd globally.
+		$credential = $this->resolve_github_credential( $repo );
+		if ( is_wp_error( $credential ) ) {
+			return array(
+				'success'       => false,
+				'slug'          => $slug,
+				'repo'          => $repo,
+				'branch'        => $branch,
+				'worktree_path' => $worktree_path,
+				'error'         => 'GitHub credential resolution failed: ' . $credential->get_error_message(),
+			);
+		}
+		$token = (string) ( $credential['token'] ?? '' );
+		if ( '' === $token ) {
+			return array(
+				'success'       => false,
+				'slug'          => $slug,
+				'repo'          => $repo,
+				'branch'        => $branch,
+				'worktree_path' => $worktree_path,
+				'error'         => 'GitHub credential resolver returned an empty token.',
+			);
+		}
+
 		// 1. Create a fresh worktree via DMC.
 		$worktree = $this->run_command(
 			sprintf(
@@ -375,14 +405,11 @@ class ECRoadie_ApplyCodeChange extends BaseTool {
 			);
 		}
 
-		// 5. Push.
-		$push = $this->run_command(
-			sprintf(
-				'cd %s && git push -u origin %s 2>&1',
-				escapeshellarg( $worktree_path ),
-				escapeshellarg( $branch )
-			)
-		);
+		// 5. Push. Token authorization passed via -c http.extraheader so
+		// the credential never lands in a remote URL, in a credential cache,
+		// or in any global git config. Per-command, per-invocation only.
+		$push = $this->run_command( $this->build_push_command( $worktree_path, $branch, $token ) );
+		$push['output'] = $this->redact_token( (string) $push['output'], $token );
 		if ( 0 !== $push['exit_code'] ) {
 			return array(
 				'success'       => false,
@@ -399,17 +426,12 @@ class ECRoadie_ApplyCodeChange extends BaseTool {
 		$proposer_line = $proposer_id > 0 ? sprintf( "\n\nProposed via roadie chat by user %d.", $proposer_id ) : '';
 		$pr_body       = $commit_message . $proposer_line . "\n\nArtifact id: `" . $bundle['id'] . "`";
 
+		// gh pr create reads GH_TOKEN from its own per-command env — passed
+		// inline in the command string, never via putenv() on the PHP process.
 		$pr = $this->run_command(
-			sprintf(
-				'cd %s && gh pr create --repo %s --base %s --head %s --title %s --body %s 2>&1',
-				escapeshellarg( $worktree_path ),
-				escapeshellarg( $repo ),
-				escapeshellarg( $default_branch ),
-				escapeshellarg( $branch ),
-				escapeshellarg( $commit_message ),
-				escapeshellarg( $pr_body )
-			)
+			$this->build_pr_create_command( $worktree_path, $repo, $default_branch, $branch, $commit_message, $pr_body, $token )
 		);
+		$pr['output'] = $this->redact_token( (string) $pr['output'], $token );
 		if ( 0 !== $pr['exit_code'] ) {
 			return array(
 				'success'       => false,
@@ -551,5 +573,102 @@ class ECRoadie_ApplyCodeChange extends BaseTool {
 			return $m[0];
 		}
 		return '';
+	}
+
+	/**
+	 * Test seam: ask the resolver whether GitHub auth is configured at all.
+	 *
+	 * @return bool
+	 */
+	protected function resolver_is_configured(): bool {
+		return GitHubCredentialResolver::isConfigured();
+	}
+
+	/**
+	 * Test seam: resolve a GitHub credential scoped to the given repo.
+	 *
+	 * Returns the resolver's success array shape:
+	 *   array{ mode, token, authorization, profile_id, cached?, expires_at? }
+	 * or a WP_Error on failure.
+	 *
+	 * @param string $repo `owner/repo` slug.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	protected function resolve_github_credential( string $repo ) {
+		return GitHubCredentialResolver::resolve( null, null, array( 'repo' => $repo ) );
+	}
+
+	/**
+	 * Build the `git push` shell command, threading the resolved token via
+	 * `-c http.extraheader=...` so the credential never touches global git
+	 * config, the credential cache, or the remote URL.
+	 *
+	 * Exposed as a protected method so tests can capture the constructed
+	 * command string without executing it.
+	 *
+	 * @param string $worktree_path Absolute path to the worktree on disk.
+	 * @param string $branch        Branch to push.
+	 * @param string $token         Resolved GitHub token (PAT or ghs_... installation token).
+	 * @return string
+	 */
+	protected function build_push_command( string $worktree_path, string $branch, string $token ): string {
+		return sprintf(
+			'cd %s && git -c http.extraheader="Authorization: Bearer %s" push -u origin %s 2>&1',
+			escapeshellarg( $worktree_path ),
+			escapeshellarg( $token ),
+			escapeshellarg( $branch )
+		);
+	}
+
+	/**
+	 * Build the `gh pr create` shell command with the resolved token passed
+	 * as a per-command `GH_TOKEN=` env prefix — never via putenv() on the
+	 * global PHP process.
+	 *
+	 * @param string $worktree_path
+	 * @param string $repo
+	 * @param string $default_branch
+	 * @param string $branch
+	 * @param string $title
+	 * @param string $body
+	 * @param string $token
+	 * @return string
+	 */
+	protected function build_pr_create_command(
+		string $worktree_path,
+		string $repo,
+		string $default_branch,
+		string $branch,
+		string $title,
+		string $body,
+		string $token
+	): string {
+		return sprintf(
+			'cd %s && GH_TOKEN=%s gh pr create --repo %s --base %s --head %s --title %s --body %s 2>&1',
+			escapeshellarg( $worktree_path ),
+			escapeshellarg( $token ),
+			escapeshellarg( $repo ),
+			escapeshellarg( $default_branch ),
+			escapeshellarg( $branch ),
+			escapeshellarg( $title ),
+			escapeshellarg( $body )
+		);
+	}
+
+	/**
+	 * Redact a token from arbitrary command output before it surfaces in
+	 * tool responses, logs, or artifact bundles. Belt-and-suspenders: most
+	 * git/gh commands shouldn't echo the token, but `set -x`-style traces,
+	 * 401 responses, or push URLs can leak it.
+	 *
+	 * @param string $output Raw command output.
+	 * @param string $token  Token to redact.
+	 * @return string
+	 */
+	protected function redact_token( string $output, string $token ): string {
+		if ( '' === $token ) {
+			return $output;
+		}
+		return str_replace( $token, '[REDACTED]', $output );
 	}
 }

--- a/inc/tools/class-propose-code-change.php
+++ b/inc/tools/class-propose-code-change.php
@@ -32,6 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineCode\Support\GitHubCredentialResolver;
 
 class ECRoadie_ProposeCodeChange extends BaseTool {
 
@@ -107,6 +108,16 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 		if ( ! $ability ) {
 			return $this->buildErrorResponse(
 				'The `wp-codebox/run-agent-task` ability is not registered. Install and activate the wp-codebox plugin on this network.',
+				$this->tool_slug
+			);
+		}
+
+		// Fail fast if GitHub credentials are not configured. There is no
+		// point dispatching an expensive sandbox run when the eventual
+		// apply-back step cannot push or open a PR.
+		if ( ! $this->resolver_is_configured() ) {
+			return $this->buildErrorResponse(
+				'GitHub credentials are not configured. The apply-back step resolves a token per repo via the Data Machine credential profile system. Verify with `wp --allow-root --path=/var/www/extrachill.com datamachine-code github status`, and configure via the `datamachine/update-settings` ability with `github_credential_profiles` + `github_default_profile_id`.',
 				$this->tool_slug
 			);
 		}
@@ -287,5 +298,14 @@ class ECRoadie_ProposeCodeChange extends BaseTool {
 			),
 			'raw'              => $result,
 		);
+	}
+
+	/**
+	 * Test seam: ask the resolver whether GitHub auth is configured at all.
+	 *
+	 * @return bool
+	 */
+	protected function resolver_is_configured(): bool {
+		return GitHubCredentialResolver::isConfigured();
 	}
 }

--- a/tests/_stub-github-credential-resolver.php
+++ b/tests/_stub-github-credential-resolver.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Test stub for DataMachineCode\Support\GitHubCredentialResolver.
+ *
+ * Defaults to "configured + returns a fake token" so smoke tests that only
+ * care about command shape pass without per-test setup. Tests that need
+ * other behavior reach into the static state directly:
+ *
+ *   GitHubCredentialResolver::$test_is_configured = false;
+ *   GitHubCredentialResolver::$test_resolve_return = new WP_Error( 'x', 'no creds' );
+ *   GitHubCredentialResolver::$test_resolve_return = array( 'token' => 'ghs_TEST_TOKEN', ... );
+ *
+ * Static call history is captured in
+ * $GLOBALS['ec_roadie_test_resolver_calls'] for assertions about selector
+ * shape (e.g. that `repo` was passed).
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+namespace DataMachineCode\Support;
+
+final class GitHubCredentialResolver {
+
+	public static bool $test_is_configured = true;
+
+	/** @var array<string,mixed>|\WP_Error */
+	public static $test_resolve_return = array(
+		'mode'          => 'app',
+		'token'         => 'ghs_TEST_TOKEN',
+		'authorization' => 'Bearer ghs_TEST_TOKEN',
+		'profile_id'    => 'homeboy-ci',
+		'cached'        => false,
+		'expires_at'    => '2099-01-01T00:00:00Z',
+	);
+
+	public static function isConfigured(): bool {
+		$GLOBALS['ec_roadie_test_resolver_calls'][] = array( 'method' => 'isConfigured' );
+		return self::$test_is_configured;
+	}
+
+	/**
+	 * @param callable|null            $http_request
+	 * @param int|null                 $now
+	 * @param array<string,mixed>|null $selector
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function resolve( ?callable $http_request = null, ?int $now = null, ?array $selector = null ) {
+		$GLOBALS['ec_roadie_test_resolver_calls'][] = array(
+			'method'   => 'resolve',
+			'selector' => $selector,
+		);
+		return self::$test_resolve_return;
+	}
+
+	public static function ec_roadie_test_reset(): void {
+		self::$test_is_configured  = true;
+		self::$test_resolve_return = array(
+			'mode'          => 'app',
+			'token'         => 'ghs_TEST_TOKEN',
+			'authorization' => 'Bearer ghs_TEST_TOKEN',
+			'profile_id'    => 'homeboy-ci',
+			'cached'        => false,
+			'expires_at'    => '2099-01-01T00:00:00Z',
+		);
+		$GLOBALS['ec_roadie_test_resolver_calls'] = array();
+	}
+}

--- a/tests/contribute-code-apply-auth.php
+++ b/tests/contribute-code-apply-auth.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Smoke test for issue #22: apply_code_change uses GitHubCredentialResolver
+ * for git push + gh pr create, threads the token via per-command env, and
+ * never putenv()s GITHUB_TOKEN globally.
+ *
+ * Strategy: poke the command-builder protected methods directly via a test
+ * subclass, exercise the resolver test seam with the stub resolver, and
+ * statically scan the source for `putenv( 'GITHUB_TOKEN'` to lock in the
+ * "no global env" rule.
+ *
+ * Run with: php tests/contribute-code-apply-auth.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/contribute-code-bootstrap.php';
+require_once __DIR__ . '/_stub-github-credential-resolver.php';
+
+// WP_Error stub for resolver-failure path.
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public string $code;
+		public string $message;
+		public function __construct( string $code = '', string $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+// BaseTool stub.
+if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
+	eval(
+		'namespace DataMachine\\Engine\\AI\\Tools;
+		abstract class BaseTool {
+			protected function registerTool( string $toolName, $toolDefinition, array $modes = array(), array $meta = array() ): void {}
+			protected function buildErrorResponse( string $error, string $tool_name ): array {
+				return array( "success" => false, "error" => $error, "tool_name" => $tool_name );
+			}
+			protected function buildDiagnosticErrorResponse( string $error, string $type, string $tool_name, array $a = array(), array $b = array() ): array {
+				return array( "success" => false, "error" => $error, "type" => $type, "tool_name" => $tool_name );
+			}
+		}'
+	);
+}
+
+// Capability cap constant.
+if ( ! defined( 'EXTRACHILL_ROADIE_PROPOSE_CODE_CAP' ) ) {
+	require_once dirname( __DIR__ ) . '/inc/contribute-code/capabilities.php';
+}
+
+require_once dirname( __DIR__ ) . '/inc/tools/class-apply-code-change.php';
+
+// Test subclass exposes protected command builders + seam overrides.
+final class ECRoadie_TestableApplyCodeChange extends ECRoadie_ApplyCodeChange {
+	public array $captured_commands     = array();
+	public array $captured_resolve_calls = array();
+	/** @var array<string,mixed>|WP_Error */
+	public $resolve_return = array(
+		'mode'          => 'app',
+		'token'         => 'ghs_TEST_TOKEN',
+		'authorization' => 'Bearer ghs_TEST_TOKEN',
+		'profile_id'    => 'homeboy-ci',
+	);
+	public bool $is_configured = true;
+
+	public function call_build_push_command( string $worktree_path, string $branch, string $token ): string {
+		return $this->build_push_command( $worktree_path, $branch, $token );
+	}
+
+	public function call_build_pr_create_command(
+		string $worktree_path,
+		string $repo,
+		string $default_branch,
+		string $branch,
+		string $title,
+		string $body,
+		string $token
+	): string {
+		return $this->build_pr_create_command( $worktree_path, $repo, $default_branch, $branch, $title, $body, $token );
+	}
+
+	public function call_redact_token( string $output, string $token ): string {
+		return $this->redact_token( $output, $token );
+	}
+
+	protected function resolver_is_configured(): bool {
+		return $this->is_configured;
+	}
+
+	protected function resolve_github_credential( string $repo ) {
+		$this->captured_resolve_calls[] = $repo;
+		return $this->resolve_return;
+	}
+
+	protected function run_command( string $cmd ): array {
+		$this->captured_commands[] = $cmd;
+		// Default: pretend the command succeeded with no output.
+		return array(
+			'exit_code' => 0,
+			'output'    => '',
+		);
+	}
+}
+
+$tool = new ECRoadie_TestableApplyCodeChange();
+
+// --- build_push_command -----------------------------------------------
+$push_cmd = $tool->call_build_push_command( '/tmp/wt', 'roadie/foo', 'ghs_TEST_TOKEN' );
+
+roadie_test_assert(
+	false !== strpos( $push_cmd, 'http.extraheader="Authorization: Bearer' ),
+	'push command must thread the token via http.extraheader, not a remote URL'
+);
+roadie_test_assert(
+	false !== strpos( $push_cmd, 'ghs_TEST_TOKEN' ),
+	'push command must contain the resolved token'
+);
+roadie_test_assert(
+	false !== strpos( $push_cmd, "'roadie/foo'" ),
+	'push command must reference the branch'
+);
+roadie_test_assert(
+	false === strpos( $push_cmd, 'GITHUB_TOKEN' ),
+	'push command must NOT reference GITHUB_TOKEN env var'
+);
+roadie_test_assert(
+	0 === strpos( $push_cmd, "cd '/tmp/wt' && git " ),
+	'push command must cd into the worktree first'
+);
+
+// --- build_pr_create_command ------------------------------------------
+$pr_cmd = $tool->call_build_pr_create_command(
+	'/tmp/wt',
+	'Extra-Chill/foo',
+	'main',
+	'roadie/foo',
+	'fix(foo): test title',
+	'PR body',
+	'ghs_TEST_TOKEN'
+);
+
+roadie_test_assert(
+	1 === preg_match( "#^cd '/tmp/wt' && GH_TOKEN='ghs_TEST_TOKEN' gh pr create #", $pr_cmd ),
+	'gh pr create must start with `cd <worktree> && GH_TOKEN=<token> gh pr create`'
+);
+roadie_test_assert(
+	false !== strpos( $pr_cmd, "--repo 'Extra-Chill/foo'" ),
+	'gh pr create must pass --repo'
+);
+roadie_test_assert(
+	false !== strpos( $pr_cmd, "--base 'main'" ),
+	'gh pr create must pass --base'
+);
+roadie_test_assert(
+	false !== strpos( $pr_cmd, "--head 'roadie/foo'" ),
+	'gh pr create must pass --head'
+);
+roadie_test_assert(
+	false === strpos( $pr_cmd, 'GITHUB_TOKEN' ),
+	'gh pr create must NOT reference GITHUB_TOKEN env var'
+);
+
+// --- redact_token ------------------------------------------------------
+$leaky      = 'remote: error pushing to https://x-access-token:ghs_TEST_TOKEN@github.com/...';
+$redacted   = $tool->call_redact_token( $leaky, 'ghs_TEST_TOKEN' );
+roadie_test_assert(
+	false === strpos( $redacted, 'ghs_TEST_TOKEN' ),
+	'redact_token must strip the token from output'
+);
+roadie_test_assert(
+	false !== strpos( $redacted, '[REDACTED]' ),
+	'redact_token must insert [REDACTED] placeholder'
+);
+roadie_test_assert(
+	'no token here' === $tool->call_redact_token( 'no token here', '' ),
+	'redact_token must no-op on empty token'
+);
+
+// --- Resolver WP_Error short-circuits the apply flow ------------------
+//
+// We exercise the full handle_tool_call path with a missing artifact to
+// hit the resolver_is_configured() gate first. Then we drive apply_to_mount
+// directly via a focused harness to test the WP_Error short-circuit on a
+// per-repo resolver call.
+
+$tool_block         = new ECRoadie_TestableApplyCodeChange();
+$tool_block->is_configured = false;
+// User cap stub.
+$GLOBALS['extrachill_roadie_test_state']['user_caps'][ EXTRACHILL_ROADIE_PROPOSE_CODE_CAP ] = true;
+$blocked = $tool_block->handle_tool_call( array( 'artifact_id' => 'whatever' ) );
+roadie_test_assert(
+	false === $blocked['success'],
+	'apply must fail when resolver_is_configured() returns false'
+);
+roadie_test_assert(
+	false !== strpos( $blocked['error'] ?? '', 'credentials are not configured' ),
+	'apply error must reference credential profile system'
+);
+roadie_test_assert(
+	empty( $tool_block->captured_commands ),
+	'no shell commands must run when resolver is not configured'
+);
+
+// --- Resolver WP_Error path (configured but resolve() returns WP_Error) -
+$resolver_error_tool = new ECRoadie_TestableApplyCodeChange();
+$resolver_error_tool->is_configured  = true;
+$resolver_error_tool->resolve_return = new WP_Error( 'github_app_token_exchange_failed', 'simulated upstream 401' );
+
+// Drive apply_to_mount via reflection to bypass artifact-bundle loading.
+$reflect = new ReflectionMethod( ECRoadie_TestableApplyCodeChange::class, 'apply_to_mount' );
+$reflect->setAccessible( true );
+
+$entry = array(
+	'mount_index'   => 0,
+	'mount'         => array(
+		'mode'     => 'readwrite',
+		'target'   => '/wordpress/wp-content/plugins/foo',
+		'metadata' => array(
+			'slug'           => 'foo',
+			'repo'           => 'Extra-Chill/foo',
+			'default_branch' => 'main',
+		),
+	),
+	'changed_paths' => array( 'file.php' ),
+);
+$bundle = array(
+	'id'           => 'artifact-foo',
+	'_bundle_dir'  => sys_get_temp_dir(),
+	'_patch_path'  => sys_get_temp_dir() . '/patch.diff',
+	'context'      => array( 'proposer_user_id' => 1 ),
+);
+
+// extrachill_roadie_workspace_root() must exist; ensure primary clone path
+// "exists" by pointing the helper at a real dir if needed.
+if ( ! function_exists( 'extrachill_roadie_workspace_root' ) ) {
+	function extrachill_roadie_workspace_root(): string {
+		return sys_get_temp_dir() . '/ec-roadie-test-workspace';
+	}
+}
+@mkdir( extrachill_roadie_workspace_root() . '/foo', 0700, true );
+
+$result = $reflect->invoke( $resolver_error_tool, $entry, 'artifact-foo', '', $bundle );
+
+roadie_test_assert(
+	false === $result['success'],
+	'apply_to_mount must fail when resolver returns WP_Error'
+);
+roadie_test_assert(
+	false !== strpos( $result['error'] ?? '', 'GitHub credential resolution failed' ),
+	'apply_to_mount error must explain the resolver failure'
+);
+roadie_test_assert(
+	false !== strpos( $result['error'] ?? '', 'simulated upstream 401' ),
+	'apply_to_mount error must include the underlying resolver message'
+);
+roadie_test_assert(
+	empty( $resolver_error_tool->captured_commands ),
+	'no shell commands must run after the resolver fails'
+);
+
+// --- Resolver is called with the repo selector -----------------------
+roadie_test_assert(
+	! empty( $resolver_error_tool->captured_resolve_calls ),
+	'resolve_github_credential() must be invoked'
+);
+roadie_test_assert(
+	'Extra-Chill/foo' === $resolver_error_tool->captured_resolve_calls[0],
+	'resolve_github_credential() must receive the per-repo selector'
+);
+
+// --- Static check: no putenv('GITHUB_TOKEN'... in the apply source ----
+$apply_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/tools/class-apply-code-change.php' );
+roadie_test_assert(
+	false === strpos( $apply_source, "putenv( 'GITHUB_TOKEN" ),
+	'class-apply-code-change.php must not putenv() GITHUB_TOKEN (issue #22)'
+);
+roadie_test_assert(
+	false === strpos( $apply_source, 'putenv("GITHUB_TOKEN' ),
+	'class-apply-code-change.php must not putenv() GITHUB_TOKEN (double-quoted)'
+);
+roadie_test_assert(
+	false === strpos( $apply_source, "getenv( 'GITHUB_TOKEN" ),
+	'class-apply-code-change.php must not getenv(GITHUB_TOKEN) (issue #22)'
+);
+
+echo "contribute-code apply-auth smoke passed.\n";

--- a/tests/contribute-code-capabilities.php
+++ b/tests/contribute-code-capabilities.php
@@ -53,35 +53,22 @@ roadie_test_assert(
 	'author should receive the cap after filter override'
 );
 
-// --- apply-tool GitHub token helpers (host-only, never crosses to sandbox) -
-roadie_test_reset_filters();
+// --- Apply-back GitHub token helpers removed (issue #22) ------------------
+//
+// The previous `extrachill_roadie_apply_github_token_env_name()` and
+// `_present()` helpers (plus the `extrachill_roadie_apply_github_token_env`
+// filter) were deleted when apply-back switched to
+// DataMachineCode\Support\GitHubCredentialResolver. Both tools now resolve a
+// per-repo token via the credential profile system; nothing in the
+// extrachill-roadie surface should reach for those names anymore. Assert
+// they really are gone so future drift fails loudly here.
 roadie_test_assert(
-	'GITHUB_TOKEN' === extrachill_roadie_apply_github_token_env_name(),
-	'default apply-back env var should be GITHUB_TOKEN'
-);
-
-putenv( 'GITHUB_TOKEN=' );
-roadie_test_assert(
-	! extrachill_roadie_apply_github_token_present(),
-	'empty GITHUB_TOKEN must not count as present'
-);
-
-putenv( 'GITHUB_TOKEN=ghp_real_token_value' );
-roadie_test_assert(
-	extrachill_roadie_apply_github_token_present(),
-	'non-empty GITHUB_TOKEN must count as present'
-);
-
-// --- filter override of env var name ------------------------------------
-add_filter( 'extrachill_roadie_apply_github_token_env', fn() => 'EC_BOT_GH_TOKEN' );
-putenv( 'EC_BOT_GH_TOKEN=hello' );
-roadie_test_assert(
-	'EC_BOT_GH_TOKEN' === extrachill_roadie_apply_github_token_env_name(),
-	'filter override on apply-back env var name'
+	! function_exists( 'extrachill_roadie_apply_github_token_env_name' ),
+	'extrachill_roadie_apply_github_token_env_name() must be removed (issue #22)'
 );
 roadie_test_assert(
-	extrachill_roadie_apply_github_token_present(),
-	'filter-overridden env var should be detected'
+	! function_exists( 'extrachill_roadie_apply_github_token_present' ),
+	'extrachill_roadie_apply_github_token_present() must be removed (issue #22)'
 );
 
 echo "contribute-code capabilities smoke passed.\n";

--- a/tests/contribute-code-tool-registration.php
+++ b/tests/contribute-code-tool-registration.php
@@ -9,6 +9,28 @@
  */
 
 require_once __DIR__ . '/contribute-code-bootstrap.php';
+require_once __DIR__ . '/_stub-github-credential-resolver.php';
+
+// WP_Error stub for the apply-tool error-path assertions below.
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public string $code;
+		public string $message;
+		public function __construct( string $code = '', string $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
 
 // Provide a stub BaseTool so the tool classes can be loaded.
 if ( ! class_exists( 'DataMachine\\Engine\\AI\\Tools\\BaseTool' ) ) {
@@ -107,17 +129,25 @@ roadie_test_assert(
 	'empty apply artifact_id must fail'
 );
 
-// --- Apply: missing GITHUB_TOKEN fails with clear error -----------------
-putenv( 'GITHUB_TOKEN=' );
+// --- Apply: resolver-not-configured fails with clear error --------------
+// Issue #22: apply-back gates on GitHubCredentialResolver::isConfigured()
+// rather than a process-env GITHUB_TOKEN check.
+\DataMachineCode\Support\GitHubCredentialResolver::$test_is_configured = false;
 $result_no_token = $apply->handle_tool_call( array( 'artifact_id' => 'artifact-bundle-foo' ) );
 roadie_test_assert(
 	false === $result_no_token['success'],
-	'apply must fail when GITHUB_TOKEN is unset'
+	'apply must fail when GitHubCredentialResolver::isConfigured() is false'
 );
 roadie_test_assert(
-	false !== strpos( $result_no_token['error'] ?? '', 'GITHUB_TOKEN' ),
-	'apply error must mention GITHUB_TOKEN'
+	false !== strpos( $result_no_token['error'] ?? '', 'credentials are not configured' )
+		|| false !== strpos( $result_no_token['error'] ?? '', 'datamachine-code github status' ),
+	'apply error must reference the credential profile system, not a GITHUB_TOKEN env var'
 );
+roadie_test_assert(
+	false === strpos( $result_no_token['error'] ?? '', 'GITHUB_TOKEN' ),
+	'apply error must NOT mention GITHUB_TOKEN env var (issue #22)'
+);
+\DataMachineCode\Support\GitHubCredentialResolver::ec_roadie_test_reset();
 
 // --- Propose: missing wp_get_ability surfaces a useful error -----------
 $result_no_ability = $propose->handle_tool_call( array( 'task_description' => 'do a thing' ) );


### PR DESCRIPTION
Closes #22.

## Summary

Refactors `apply_code_change` (and adds a fail-fast precondition to `propose_code_change`) so the contribute-code flow resolves GitHub credentials via `DataMachineCode\Support\GitHubCredentialResolver` instead of reading a `GITHUB_TOKEN` env var from the PHP process. The resolved token is threaded into each shell-out via per-command env — `git -c http.extraheader=...` for `git push`, `GH_TOKEN=...` for `gh pr create` — never via global `putenv()`.

This closes the identity gap from #20: PRs opened via this path are now authored by the resolved credential profile's identity (e.g. `homeboy-ci[bot]` for App-mode profiles), not by whoever owns the legacy PAT.

## What changed

- **`inc/tools/class-apply-code-change.php`** — credential minted once per repo at the top of `apply_to_mount()` via `GitHubCredentialResolver::resolve(['repo' => $repo])`. New protected `build_push_command()` / `build_pr_create_command()` builders make the shell-out shape testable. New `redact_token()` scrubs the token from any leaked command output. New `resolver_is_configured()` / `resolve_github_credential()` seams let smoke tests drive resolver outcomes.
- **`inc/tools/class-propose-code-change.php`** — adds a `resolver_is_configured()` fail-fast precondition so users get a clear error before an expensive sandbox dispatch when GitHub auth is missing.
- **`inc/contribute-code/capabilities.php`** — `extrachill_roadie_apply_github_token_env_name()` + `_present()` (and the `extrachill_roadie_apply_github_token_env` filter) are deleted. A removal-note comment is kept for archaeological context.
- **`docs/contribute-code.md`** — drops the `putenv( 'GITHUB_TOKEN=...' )` wp-config setup section. Replaces with the credential profile workflow (`wp datamachine-code github status` to verify, `datamachine/update-settings` ability with `github_credential_profiles` + `github_default_profile_id` to configure). Architecture diagram + commit-identity note updated accordingly.
- **`tests/contribute-code-apply-auth.php`** (new) — focused smoke test covering all the acceptance criteria below.
- **`tests/_stub-github-credential-resolver.php`** (new) — static-state stub so smoke tests can flip `isConfigured()` and shape the `resolve()` return without booting WordPress or Data Machine Code.
- **`tests/contribute-code-capabilities.php`** — replaces the deleted env-var helper assertions with a "those functions are gone" guard so future drift fails loudly here.
- **`tests/contribute-code-tool-registration.php`** — updated the apply-tool error-path assertion to the new resolver-not-configured contract; explicitly asserts the error no longer mentions `GITHUB_TOKEN`.

## Acceptance criteria — issue #22

- [x] **`class-apply-code-change.php` resolves credentials via `GitHubCredentialResolver::resolve(['repo' => $repo])` before each `git push` / `gh pr create`.**
  Evidence: `inc/tools/class-apply-code-change.php` `apply_to_mount()` calls `resolve_github_credential( $repo )` once per repo (which delegates to the resolver with the `repo` selector). Token then threaded into both shell-outs.

- [x] **Token passed via per-command env (`git -c http.extraheader=...` for push, `GH_TOKEN=...` for gh), never via `putenv()` global env.**
  Evidence: `build_push_command()` / `build_pr_create_command()` in `class-apply-code-change.php`. Smoke test `tests/contribute-code-apply-auth.php` asserts the command shapes plus a static check that no `putenv("GITHUB_TOKEN"` / `getenv("GITHUB_TOKEN"` calls remain in the apply source.

- [x] **Error path: when resolver returns WP_Error, return a clean apply-back failure result.**
  Evidence: `apply_to_mount()` returns an early failure dict with `error = "GitHub credential resolution failed: ..."` and no shell-outs run. Smoke test `tests/contribute-code-apply-auth.php` "Resolver WP_Error path" block exercises this via reflection.

- [x] **`extrachill_roadie_apply_github_token_env_name()` / `_present()` removed; `class-propose-code-change.php` precondition updated to check resolver `isConfigured()` instead.**
  Evidence: `inc/contribute-code/capabilities.php` (helpers gone, removal note in place). `inc/tools/class-propose-code-change.php` now calls `$this->resolver_is_configured()` after the `wp_get_ability` check. `tests/contribute-code-capabilities.php` asserts both helper functions no longer exist.

- [x] **`docs/contribute-code.md` updated: drop `putenv(GITHUB_TOKEN=...)` setup, document `wp datamachine-code github status` as the way to verify auth.**
  Evidence: `docs/contribute-code.md` section "GitHub credentials (host-only, for apply-back)" rewritten end-to-end.

- [x] **Smoke test added to `tests/`: mocked resolver returns a token; assert it appears in the constructed `git push` and `gh pr create` commands; resolver returning `WP_Error` short-circuits cleanly.**
  Evidence: `tests/contribute-code-apply-auth.php`. Also adds redact-token coverage and a static-source guard against `putenv`/`getenv` `GITHUB_TOKEN` regressions.

## App identity verification

When the default credential profile is `homeboy-ci` (App ID `3034937`, installation `114752821` — wired and smoke-verified end-to-end on the VPS in issue #20, now closed), `GitHubCredentialResolver::resolve()` returns a fresh `ghs_...` installation token good for ~1 hour. PRs opened via `gh pr create` with that token in `GH_TOKEN=` are authored by `homeboy-ci[bot]`, not by a personal PAT. This is the exact identity gap that motivated #22.

## Token handling

- Tokens are passed to `escapeshellarg()` before insertion into the command string (they contain `_`, `:`, and case-sensitive chars that must shell-quote).
- `redact_token()` is applied to both `git push` and `gh pr create` output before any error message lands in a tool response or artifact.
- Sandbox-side auth is unchanged: the sandbox never pushes, the token never crosses the sandbox boundary (see `secret_env` allow-list contract from PR #13).

## Test status

All 11 smoke tests pass:

```
Roadie agent mode registration smoke passed (14 assertions).
Roadie calling-user identity smoke passed (12 assertions).
Roadie calling-user permission denial smoke passed (28 assertions).
contribute-code apply-auth smoke passed.
contribute-code capabilities smoke passed.
contribute-code inherit-resolver smoke passed.
contribute-code recipe-builder smoke passed.
contribute-code subsite-context smoke passed.
contribute-code tool-registration smoke passed.
feature-request tool smoke passed.
Roadie frontend chat branding smoke passed (3 assertions).
```

## Out of scope

- No CHANGELOG edits / version bumps — homeboy owns those via conventional commits at release time.
- No changes to `data-machine-code` or any other repo. The fix lives entirely in `extrachill-roadie`.
- Sandbox-side auth, OpenAI inheritance, recipe building — all untouched.