### PR TITLE
chore(lint): satisfy phpcs WordPress coding standards (unblock v0.8.0)

### DIFF
--- a/inc/contribute-code/inherit-resolver.php
+++ b/inc/contribute-code/inherit-resolver.php
@@ -119,7 +119,10 @@ function extrachill_roadie_resolve_inheritance( $resolution, $request, $input ):
 	unset( $input );
 
 	if ( ! is_array( $resolution ) ) {
-		$resolution = array( 'connectors' => array(), 'settings' => array() );
+		$resolution = array(
+			'connectors' => array(),
+			'settings'   => array(),
+		);
 	}
 
 	$connector_map = extrachill_roadie_default_connector_map();
@@ -150,7 +153,11 @@ function extrachill_roadie_resolve_inheritance( $resolution, $request, $input ):
 
 		// Bridge: export the value into the host PHP process env under the
 		// configured env var name. WP Codebox's secret_env will inherit it.
+		// This is the intentional temporary bridge documented in PR #13 — it
+		// is removed when wp-codebox's inheritance contract supports
+		// filter-returned values directly (chubes4/wp-codebox#88).
 		if ( ! empty( $meta['env_var'] ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv -- Intentional secret_env bridge to wp-codebox; see comment above.
 			putenv( $meta['env_var'] . '=' . $value );
 		}
 

--- a/inc/contribute-code/recipe-builder.php
+++ b/inc/contribute-code/recipe-builder.php
@@ -151,7 +151,7 @@ function extrachill_roadie_build_recipe( array $context, array $repo_map, array 
 			$target = $wp_content_target . '/themes/' . $theme_slug;
 			$mount  = $build_mount( 'theme', $theme_slug, $entry, $target );
 			if ( $mount ) {
-				$mounts[]                       = $mount;
+				$mounts[]                        = $mount;
 				$editable_targets[ $theme_slug ] = $target;
 			}
 		} else {

--- a/inc/contribute-code/repo-map.php
+++ b/inc/contribute-code/repo-map.php
@@ -42,63 +42,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 function extrachill_roadie_default_repo_map(): array {
 	$defaults = array(
 		// Themes.
-		'extrachill' => array(
-			'repo'                          => 'Extra-Chill/extrachill',
-			'default_branch'                => 'main',
-			'repo_root_relative_to_mount'   => '',
-			'kind'                          => 'theme',
+		'extrachill'                 => array(
+			'repo'                        => 'Extra-Chill/extrachill',
+			'default_branch'              => 'main',
+			'repo_root_relative_to_mount' => '',
+			'kind'                        => 'theme',
 		),
 
 		// Extra Chill plugins commonly active on individual subsites.
-		'extrachill-artist-platform'  => array(
+		'extrachill-artist-platform' => array(
 			'repo'                        => 'Extra-Chill/extrachill-artist-platform',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-community'        => array(
+		'extrachill-community'       => array(
 			'repo'                        => 'Extra-Chill/extrachill-community',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-events'           => array(
+		'extrachill-events'          => array(
 			'repo'                        => 'Extra-Chill/extrachill-events',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-shop'             => array(
+		'extrachill-shop'            => array(
 			'repo'                        => 'Extra-Chill/extrachill-shop',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-blog'             => array(
+		'extrachill-blog'            => array(
 			'repo'                        => 'Extra-Chill/extrachill-blog',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-contact'          => array(
+		'extrachill-contact'         => array(
 			'repo'                        => 'Extra-Chill/extrachill-contact',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-content-blocks'   => array(
+		'extrachill-content-blocks'  => array(
 			'repo'                        => 'Extra-Chill/extrachill-content-blocks',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-docs'             => array(
+		'extrachill-docs'            => array(
 			'repo'                        => 'Extra-Chill/extrachill-docs',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'plugin',
 		),
-		'extrachill-ai-adventure'     => array(
+		'extrachill-ai-adventure'    => array(
 			'repo'                        => 'Extra-Chill/extrachill-ai-adventure',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
@@ -112,73 +112,73 @@ function extrachill_roadie_default_repo_map(): array {
 		// and code-change-trackable. Listing them here keeps the registry as
 		// the single allowlist consulted by both `file_feature_request` and
 		// future explicit-repo override flows.
-		'extrachill-roadie' => array(
+		'extrachill-roadie'          => array(
 			'repo'                        => 'Extra-Chill/extrachill-roadie',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-users' => array(
+		'extrachill-users'           => array(
 			'repo'                        => 'Extra-Chill/extrachill-users',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-multisite' => array(
+		'extrachill-multisite'       => array(
 			'repo'                        => 'Extra-Chill/extrachill-multisite',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-api' => array(
+		'extrachill-api'             => array(
 			'repo'                        => 'Extra-Chill/extrachill-api',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-admin-tools' => array(
+		'extrachill-admin-tools'     => array(
 			'repo'                        => 'Extra-Chill/extrachill-admin-tools',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-newsletter' => array(
+		'extrachill-newsletter'      => array(
 			'repo'                        => 'Extra-Chill/extrachill-newsletter',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-search' => array(
+		'extrachill-search'          => array(
 			'repo'                        => 'Extra-Chill/extrachill-search',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-seo' => array(
+		'extrachill-seo'             => array(
 			'repo'                        => 'Extra-Chill/extrachill-seo',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-analytics' => array(
+		'extrachill-analytics'       => array(
 			'repo'                        => 'Extra-Chill/extrachill-analytics',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-cli' => array(
+		'extrachill-cli'             => array(
 			'repo'                        => 'Extra-Chill/extrachill-cli',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-tokens' => array(
+		'extrachill-tokens'          => array(
 			'repo'                        => 'Extra-Chill/extrachill-tokens',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'platform-plugin',
 		),
-		'extrachill-components' => array(
+		'extrachill-components'      => array(
 			'repo'                        => 'Extra-Chill/extrachill-components',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
@@ -187,31 +187,31 @@ function extrachill_roadie_default_repo_map(): array {
 
 		// Read-only agent stack (mounted as references so the sandboxed agent
 		// can grep them, but never as editable surfaces).
-		'agents-api' => array(
+		'agents-api'                 => array(
 			'repo'                        => 'Automattic/agents-api',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'agent-stack-plugin',
 		),
-		'data-machine' => array(
+		'data-machine'               => array(
 			'repo'                        => 'Extra-Chill/data-machine',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'agent-stack-plugin',
 		),
-		'data-machine-code' => array(
+		'data-machine-code'          => array(
 			'repo'                        => 'Extra-Chill/data-machine-code',
 			'default_branch'              => 'main',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'agent-stack-plugin',
 		),
-		'ai-provider-for-openai' => array(
+		'ai-provider-for-openai'     => array(
 			'repo'                        => 'WordPress/ai-provider-for-openai',
 			'default_branch'              => 'trunk',
 			'repo_root_relative_to_mount' => '',
 			'kind'                        => 'agent-stack-plugin',
 		),
-		'ai-provider-for-anthropic' => array(
+		'ai-provider-for-anthropic'  => array(
 			'repo'                        => 'WordPress/ai-provider-for-anthropic',
 			'default_branch'              => 'trunk',
 			'repo_root_relative_to_mount' => '',

--- a/inc/contribute-code/subsite-context.php
+++ b/inc/contribute-code/subsite-context.php
@@ -148,19 +148,19 @@ function extrachill_roadie_plugin_file_to_slug( string $plugin_file ): string {
  * @return array<string,mixed>
  */
 function extrachill_roadie_detect_subsite_context( ?int $blog_id = null ): array {
-	$blog_id = $blog_id ?: (int) get_current_blog_id();
+	$blog_id = ( $blog_id > 0 ) ? $blog_id : (int) get_current_blog_id();
 
 	$switched = false;
-	if ( function_exists( 'switch_to_blog' ) && $blog_id !== (int) get_current_blog_id() ) {
+	if ( function_exists( 'switch_to_blog' ) && (int) get_current_blog_id() !== $blog_id ) {
 		switch_to_blog( $blog_id );
 		$switched = true;
 	}
 
-	$theme         = wp_get_theme();
-	$stylesheet    = $theme->get_stylesheet();
-	$theme_path    = (string) $theme->get_stylesheet_directory();
-	$parent_slug   = '';
-	$parent        = $theme->parent();
+	$theme       = wp_get_theme();
+	$stylesheet  = $theme->get_stylesheet();
+	$theme_path  = (string) $theme->get_stylesheet_directory();
+	$parent_slug = '';
+	$parent      = $theme->parent();
 	if ( $parent ) {
 		$parent_slug = (string) $parent->get_stylesheet();
 	}

--- a/tests/contribute-code-apply-auth.php
+++ b/tests/contribute-code-apply-auth.php
@@ -280,6 +280,7 @@ roadie_test_assert(
 );
 
 // --- Static check: no putenv('GITHUB_TOKEN'... in the apply source ----
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Smoke test runs outside WordPress; WP_Filesystem is not available.
 $apply_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/tools/class-apply-code-change.php' );
 roadie_test_assert(
 	false === strpos( $apply_source, "putenv( 'GITHUB_TOKEN" ),


### PR DESCRIPTION
## Summary

Cleans up the 41 lint findings (3 errors, 38 warnings) that homeboy's release preflight surfaced when attempting to cut `v0.8.0`. All findings are cosmetic — no runtime behavior changes — and inherited from PRs #13 and #18 that had merged without a lint pass.

## What changed

| File | Change | Source |
|------|--------|--------|
| `inc/contribute-code/repo-map.php` | Align double arrows in the repo registry | `homeboy lint --fix` (autofix) |
| `inc/contribute-code/recipe-builder.php` | Single alignment fix | `homeboy lint --fix` (autofix) |
| `inc/contribute-code/subsite-context.php` | Yoda condition + replace `?:` short-ternary with `( $x > 0 ) ? $x : ...` | Manual |
| `inc/contribute-code/inherit-resolver.php` | Split associative array onto multiple lines; add `phpcs:ignore` for the intentional `putenv()` bridge to wp-codebox's `secret_env` | Manual |
| `tests/contribute-code-apply-auth.php` | `phpcs:ignore` for the static source-scan `file_get_contents` (smoke runs outside WordPress, no `WP_Filesystem`) | Manual |

## Autofixes intentionally reverted

`homeboy lint --fix` proposed several aggressive rewrites that would have broken runtime behavior. These were reverted:

- **`file_get_contents()` → `$wp_filesystem->get_contents()`** in `class-apply-code-change.php` and `class-file-feature-request.php`. `WP_Filesystem` is not initialized by default; this would null-deref the global at runtime.
- **`glob(...) ?: array()` → `glob(...) ? glob(...) : array()`** in `class-apply-code-change.php`. Calls `glob()` twice instead of using the null-coalescing short-circuit.

Those direct PHP filesystem uses are intentional in code paths that run outside the canonical `WP_Filesystem::init()` flow.

## Verification

```
$ homeboy lint extrachill-roadie --path .
"summary": "lint phase passed with no findings"

$ for f in tests/*.php; do php "$f" 2>&1 | tail -1; done
Roadie agent mode registration smoke passed (14 assertions).
Roadie calling-user identity smoke passed (12 assertions).
Roadie calling-user permission denial smoke passed (28 assertions).
contribute-code apply-auth smoke passed.
contribute-code capabilities smoke passed.
contribute-code inherit-resolver smoke passed.
contribute-code recipe-builder smoke passed.
contribute-code subsite-context smoke passed.
contribute-code tool-registration smoke passed.
feature-request tool smoke passed.
Roadie frontend chat branding smoke passed (3 assertions).
```

## Why this PR exists

`homeboy release extrachill-roadie --deploy` failed at the `preflight.lint` gate. Rather than `--skip-checks`, this PR pays down the small lint debt cleanly so future releases stay unblocked.

## Out of scope

- No CHANGELOG edit / version bump (homeboy owns both).
- No code logic changes.
- No new tests beyond the existing 11 smokes (all still green).