### PR TITLE
chore(homeboy): pin test_backend=host (unblock releases on the VPS)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,7 +3,11 @@
   "changelog_target": "docs/CHANGELOG.md",
   "remote_path": "wp-content/plugins/extrachill-roadie",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "settings": {
+        "test_backend": "host"
+      }
+    }
   },
   "version_targets": [
     {


### PR DESCRIPTION
## Summary

Pins `extensions.wordpress.settings.test_backend = "host"` in `homeboy.json` so the release preflight test phase runs against the VPS's host PHP/WordPress install instead of trying to spin up `@wp-playground/cli`.

## Why

The VPS (`extrachill.com`) is where homeboy actually runs for this component — it has a full WordPress multisite + every Extra Chill plugin already network-activated. Running tests through Playground is the wrong tool: it spins up an isolated WP-WASM sandbox per release, which is heavier, more brittle, and (right now) blocked because the `@wp-playground/cli` bin symlinks are missing in homeboy's extension `node_modules`.

The host backend reads the existing PHP. Our 11 smoke tests under `tests/*.php` run cleanly there (verified: 11/11 green during PR #25). Those smokes remain the real regression coverage; the test phase just wraps invoking them.

## Diff

5-line change:

```diff
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "settings": {
+        "test_backend": "host"
+      }
+    }
   },
```

## Out of scope

- No code changes, no test changes.
- This is the canonical fix suggested by homeboy itself when the missing-Playground error fires.