### PR TITLE
feat(capabilities): grant extra_chill_team the propose-code cap by default

### DIFF
--- a/inc/contribute-code/capabilities.php
+++ b/inc/contribute-code/capabilities.php
@@ -2,8 +2,8 @@
 /**
  * Capability mapping for the contribute-code chat tools.
  *
- * Adds `extrachill_propose_code` and grants it to administrators and editors
- * by default. Override the role grant via the
+ * Adds `extrachill_propose_code` and grants it to administrators, editors,
+ * and the Extra Chill team role by default. Override the role grant via the
  * `extrachill_roadie_propose_code_roles` filter; override per-user via the
  * `user_has_cap` filter as usual.
  *
@@ -28,7 +28,13 @@ const EXTRACHILL_ROADIE_PROPOSE_CODE_CAP = 'extrachill_propose_code';
  * @return string[]
  */
 function extrachill_roadie_propose_code_default_roles(): array {
-	$defaults = array( 'administrator', 'editor' );
+	// `extra_chill_team` is the Extra Chill platform's trust role — granted to
+	// team members who run the network's content + community operations. Giving
+	// the team the propose-code cap by default means any team member can file
+	// feature requests / propose code changes via Roadie chat without needing
+	// a per-user grant. Other consumers can narrow this via the
+	// `extrachill_roadie_propose_code_roles` filter below.
+	$defaults = array( 'administrator', 'editor', 'extra_chill_team' );
 
 	/**
 	 * Filter the roles that automatically get the contribute-code capability.


### PR DESCRIPTION
## Summary

Adds `extra_chill_team` to the default role list for the `extrachill_propose_code` capability. Team members can now file feature requests and propose code changes via Roadie chat without needing manual admin grant.

Verified live: `wp_get_ability('agents/chat')` smoke against Chris Gardner (user #38, `extra_chill_team` only) — pre-change the agent correctly refused with a clean permission denial; post-change the team member is trusted to file.

## Diff

```diff
-$defaults = array( 'administrator', 'editor' );
+$defaults = array( 'administrator', 'editor', 'extra_chill_team' );
```

Plus a few lines of explanatory comment noting why the team role is the natural trust pool here.

## Layer purity

This is the textbook EC-aware-consumer change. `extra_chill_team` is an Extra Chill role; the grant policy is Extra Chill platform behavior; it lives in `extrachill-roadie` which is the EC-aware wrapper around generic Data Machine + frontend-agent-chat infrastructure. The lower layers stay vendor-agnostic.

## Override hook unchanged

Consumers who want to narrow this (e.g. a site that doesn't trust its team role) can still strip the role via the existing `extrachill_roadie_propose_code_roles` filter:

```php
add_filter( 'extrachill_roadie_propose_code_roles', function( array $roles ): array {
    return array_diff( $roles, array( 'extra_chill_team' ) );
} );
```

## Test status

All 11 smoke tests still green. Lint clean.