### PR TITLE
Map chat 0.9–0.13 status tokens in Roadie token bridge

### DIFF
--- a/assets/css/token-bridge.css
+++ b/assets/css/token-bridge.css
@@ -9,13 +9,21 @@
  * Agents API abilities, not Data Machine internals. The token bridge
  * lives here in Roadie (the EC platform consumer), never in FAC.
  *
- * Token surface (all upstream from frontend-agent-chat 0.8.x):
+ * Token surface (upstream from frontend-agent-chat 0.13.x):
  *   FAB:       --frontend-agent-chat-fab-{bg,color,border-color,font-size,offset,badge-bg}
  *   Drawer:    --frontend-agent-chat-drawer-{bg,width}
  *   Surface:   --frontend-agent-chat-{accent,text-primary,text-muted,border-color,bg-muted}
  *   Typography:--frontend-agent-chat-{font-family,header-font-family,font-size,header-font-size}
  *   Spacing:   --frontend-agent-chat-spacing-{xs,sm,md,lg}
  *   Surfaces:  --frontend-agent-chat-{input-bg,message-bg,warning-bg,warning-text}
+ *   Status:    --frontend-agent-chat-{error-bg,error-border,error-detail-bg,error-text,
+ *              success-bg,success-border,success-text,accent-border,accent-soft-bg,muted-bg}
+ *              (chat 0.9–0.13: tool-card error states, artifact/generation status pills,
+ *              image thumbnails)
+ *
+ * Left to package defaults (non-branding/structural): --frontend-agent-chat-admin-bar-offset
+ * (self-managed from --wp-admin--admin-bar--height), --frontend-agent-chat-fab-offset
+ * (structural), --frontend-agent-chat-monospace-font-family (no EC mono var).
  *
  * @package ExtraChillRoadie
  * @since 0.6.0
@@ -57,4 +65,21 @@
 	--frontend-agent-chat-spacing-sm: var(--spacing-sm, 12px);
 	--frontend-agent-chat-spacing-md: var(--spacing-md, 16px);
 	--frontend-agent-chat-spacing-lg: var(--spacing-lg, 24px);
+
+	/* ── Status / tool-card surfaces (chat 0.9–0.13) ────── */
+	/* Tool-card error states, artifact/generation status pills, image
+	 * thumbnails. Map to EC brand error/success/accent so these newer
+	 * surfaces read on-brand instead of the package's slate/red/green
+	 * defaults. Soft backgrounds use --card-background (neutral, readable)
+	 * rather than colored tints to stay legible in EC light + dark modes. */
+	--frontend-agent-chat-error-bg: var(--card-background, #fef2f2);
+	--frontend-agent-chat-error-border: var(--error-color, #fecaca);
+	--frontend-agent-chat-error-detail-bg: var(--card-background, #fee2e2);
+	--frontend-agent-chat-error-text: var(--error-color, #b91c1c);
+	--frontend-agent-chat-accent-border: var(--accent, #93c5fd);
+	--frontend-agent-chat-accent-soft-bg: var(--card-background, #eff6ff);
+	--frontend-agent-chat-success-bg: var(--card-background, #f0fdf4);
+	--frontend-agent-chat-success-border: var(--success-color, #bbf7d0);
+	--frontend-agent-chat-success-text: var(--success-color, #15803d);
+	--frontend-agent-chat-muted-bg: var(--background-color, #f8f9fa);
 }


### PR DESCRIPTION
Closes #29

## Summary
The Roadie token bridge (`assets/css/token-bridge.css`) was written for the frontend-agent-chat **0.8.x** token surface and was missing the color tokens added across chat **0.9–0.13** (now bundled at v0.13.0). Tool-card error states, artifact/generation status pills, and image thumbnails were rendering the package's slate/red/green defaults instead of the EC brand palette.

## Tokens added (10)
All map to confirmed EC theme vars in `themes/extrachill/assets/css/root.css`, with package-default fallbacks, matching the existing `var(--ec, #fallback)` style:

| Token | Mapping |
|-------|---------|
| `--frontend-agent-chat-error-bg` | `var(--card-background, #fef2f2)` |
| `--frontend-agent-chat-error-border` | `var(--error-color, #fecaca)` |
| `--frontend-agent-chat-error-detail-bg` | `var(--card-background, #fee2e2)` |
| `--frontend-agent-chat-error-text` | `var(--error-color, #b91c1c)` |
| `--frontend-agent-chat-accent-border` | `var(--accent, #93c5fd)` |
| `--frontend-agent-chat-accent-soft-bg` | `var(--card-background, #eff6ff)` |
| `--frontend-agent-chat-success-bg` | `var(--card-background, #f0fdf4)` |
| `--frontend-agent-chat-success-border` | `var(--success-color, #bbf7d0)` |
| `--frontend-agent-chat-success-text` | `var(--success-color, #15803d)` |
| `--frontend-agent-chat-muted-bg` | `var(--background-color, #f8f9fa)` |

Soft backgrounds (`error-bg`, `error-detail-bg`, `accent-soft-bg`, `success-bg`) map to `--card-background` for readability in EC light + dark modes rather than colored tints.

## Left to package defaults (intentional)
- `--frontend-agent-chat-admin-bar-offset` — package self-manages from `--wp-admin--admin-bar--height`.
- `--frontend-agent-chat-fab-offset` — structural FAB placement.
- `--frontend-agent-chat-monospace-font-family` — no EC mono var.

## Also
- **Docblock refreshed**: updated from "all upstream from frontend-agent-chat 0.8.x" to 0.13.x, re-listing the surface to include the new Status tokens and noting which tokens are intentionally left to package defaults.
- **No dead mappings introduced** — additive change only.