### PR TITLE
feat: activate roadie mode + real page context in frontend chat

### DIFF
--- a/inc/frontend-chat.php
+++ b/inc/frontend-chat.php
@@ -55,7 +55,7 @@ add_filter( 'frontend_agent_chat_config', 'extrachill_roadie_frontend_chat_confi
  * @param array            $config     Frontend chat configuration.
  * @return array Modified chat input.
  */
-function extrachill_roadie_frontend_chat_input( $chat_input, $request, string $agent_slug, array $config ): array {
+function extrachill_roadie_frontend_chat_input( $chat_input, $request, string $agent_slug, array $config ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $config is required by the 4-arg frontend_agent_chat_chat_input/queue_input filter signature.
 	if ( ! is_array( $chat_input ) ) {
 		return is_array( $chat_input ) ? $chat_input : array();
 	}

--- a/inc/frontend-chat.php
+++ b/inc/frontend-chat.php
@@ -30,3 +30,130 @@ function extrachill_roadie_frontend_chat_config( array $config ): array {
 	return $config;
 }
 add_filter( 'frontend_agent_chat_config', 'extrachill_roadie_frontend_chat_config' );
+
+/**
+ * Activate Roadie execution mode + real page context for the frontend widget.
+ *
+ * The generic Frontend Agent Chat widget sends no execution mode and only a
+ * transport-level `client_context` (source/client_name/connector_id), so Data
+ * Machine defaults the turn to bare `chat`. That bare mode is location-agnostic
+ * but carries none of the Extra Chill platform context, and Roadie's registered
+ * `roadie` mode never activates because the widget never requests it.
+ *
+ * This hook — the EC-domain complement to the generic FAC seam — composes the
+ * `roadie` mode on top of `chat` (additive: roadie's EC platform directive +
+ * roadie tools) and populates `client_context` with the real page/site the
+ * user is viewing, which Data Machine's ClientContextDirective renders into the
+ * prompt so the agent has accurate location awareness.
+ *
+ * Guarded on the Roadie agent slug, mirroring the branding hook above: a
+ * non-roadie agent or a non-frontend caller is unaffected.
+ *
+ * @param array            $chat_input Canonical agents/chat input.
+ * @param \WP_REST_Request $request    REST request.
+ * @param string           $agent_slug Selected agent slug.
+ * @param array            $config     Frontend chat configuration.
+ * @return array Modified chat input.
+ */
+function extrachill_roadie_frontend_chat_input( $chat_input, $request, string $agent_slug, array $config ): array {
+	if ( ! is_array( $chat_input ) ) {
+		return is_array( $chat_input ) ? $chat_input : array();
+	}
+
+	if ( EXTRACHILL_ROADIE_AGENT_SLUG !== sanitize_title( $agent_slug ) ) {
+		return $chat_input;
+	}
+
+	$chat_input['modes']          = extrachill_roadie_compose_modes( $chat_input['modes'] ?? array() );
+	$chat_input['client_context'] = extrachill_roadie_build_client_context(
+		is_array( $chat_input['client_context'] ?? null ) ? $chat_input['client_context'] : array(),
+		$request
+	);
+
+	return $chat_input;
+}
+add_filter( 'frontend_agent_chat_chat_input', 'extrachill_roadie_frontend_chat_input', 10, 4 );
+add_filter( 'frontend_agent_chat_queue_input', 'extrachill_roadie_frontend_chat_input', 10, 4 );
+
+/**
+ * Compose the `roadie` mode on top of any modes already present.
+ *
+ * Preserves explicitly-set modes (so a future caller can request more) while
+ * guaranteeing both `chat` (the generic conversational base) and `roadie`
+ * (the EC platform context + tools) are active and de-duplicated.
+ *
+ * @param mixed $existing Existing modes from the chat input (array or scalar).
+ * @return array<int,string> Composed mode slugs.
+ */
+function extrachill_roadie_compose_modes( $existing ): array {
+	$modes = array();
+
+	if ( is_array( $existing ) ) {
+		foreach ( $existing as $mode ) {
+			$slug = sanitize_key( (string) $mode );
+			if ( '' !== $slug ) {
+				$modes[] = $slug;
+			}
+		}
+	} elseif ( is_string( $existing ) && '' !== $existing ) {
+		$slug = sanitize_key( $existing );
+		if ( '' !== $slug ) {
+			$modes[] = $slug;
+		}
+	}
+
+	$modes[] = 'chat';
+	$modes[] = EXTRACHILL_ROADIE_AGENT_SLUG;
+
+	return array_values( array_unique( $modes ) );
+}
+
+/**
+ * Populate client context with the real page/site the user is viewing.
+ *
+ * The frontend widget forwards the current page URL (and title) in the REST
+ * body; we also fall back to the request Referer header. The current EC subsite
+ * is derived from the WordPress runtime. Data Machine's ClientContextDirective
+ * renders each key into the prompt as `- key: value`, giving the agent accurate
+ * location awareness instead of guessing.
+ *
+ * @param array            $client_context Existing transport-level client context.
+ * @param \WP_REST_Request $request        REST request.
+ * @return array Enriched client context.
+ */
+function extrachill_roadie_build_client_context( array $client_context, $request ): array {
+	$page_url   = '';
+	$page_title = '';
+
+	if ( $request instanceof \WP_REST_Request ) {
+		$page_url   = esc_url_raw( (string) $request->get_param( 'page_url' ) );
+		$page_title = sanitize_text_field( (string) $request->get_param( 'page_title' ) );
+
+		if ( '' === $page_url ) {
+			$referer = (string) $request->get_header( 'referer' );
+			if ( '' !== $referer ) {
+				$page_url = esc_url_raw( $referer );
+			}
+		}
+	}
+
+	if ( '' !== $page_url ) {
+		$client_context['page_url'] = $page_url;
+	}
+
+	if ( '' !== $page_title ) {
+		$client_context['page_title'] = $page_title;
+	}
+
+	$site_name = get_bloginfo( 'name' );
+	if ( '' !== (string) $site_name ) {
+		$client_context['site'] = sanitize_text_field( (string) $site_name );
+	}
+
+	$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+	if ( is_string( $site_host ) && '' !== $site_host ) {
+		$client_context['site_host'] = $site_host;
+	}
+
+	return $client_context;
+}


### PR DESCRIPTION
Closes #30

## Summary
Activate the `roadie` execution mode and supply real page/location context for the Extra Chill frontend chat widget, by hooking the generic Frontend Agent Chat seams from the EC domain plugin.

- Hook `frontend_agent_chat_chat_input` **and** the async sibling `frontend_agent_chat_queue_input`.
- Guard on the roadie agent slug (`EXTRACHILL_ROADIE_AGENT_SLUG`), mirroring the existing `frontend_agent_chat_config` branding hook — non-roadie agents and non-frontend callers are unaffected.
- Inject `modes => ['chat','roadie']` so the `roadie` mode composes **additively** on top of generic chat (preserving any explicitly-set modes, de-duplicated).
- Populate `client_context` with the real page/site: `page_url`, `page_title`, `site`, `site_host`.

## The problem
The widget sent **no execution mode** and only transport-level `client_context` (`source`/`client_name`/`connector_id`), so Data Machine defaulted to bare `chat`. Roadie's registered `roadie` mode (EC platform directive + roadie tools) never activated because the widget never requested it, and the agent had no way to know which EC page/site the user was on.

## How it works (code trace)
```
FAC POST /chat  body: { page_url, page_title, agent:'roadie', message }
   → FAC rest.php builds chat_input, fires frontend_agent_chat_chat_input
   → THIS hook (slug guard) sets modes=['chat','roadie'] + enriches client_context
   → agents/chat ability → DM AgentsChatHandler::resolveModes reads $input['modes']
   → PromptBuilder/AgentModeDirective fires datamachine_agent_mode_roadie
       (extrachill-roadie/inc/agent-mode/register.php → EC platform guidance)
   → DM ClientContextDirective renders page_url/site into the prompt
```

## Page URL source
Reads `page_url`/`page_title` from the REST body (forwarded by FAC — see frontend-agent-chat#62), with a `Referer` header fallback so it degrades gracefully if the body field is absent. Site name/host come from the WordPress runtime.

## Depends on
- frontend-agent-chat#62 — forwards `window.location` through the chat REST body (generic, runtime-agnostic). The `Referer` fallback means roadie still gets a page URL even before that merges, but #62 makes it robust against referrer-policy.
- Unblocked by data-machine#2425 (generic `chat` is now clean/location-agnostic; `roadie` composes on top).

## Layer purity
All EC/product-specific wiring lives **here** in the domain plugin. FAC stays runtime-agnostic (only forwards the current page); DM core stays generic. Same boundary the existing branding hook already respects.

## Verification
- PHP lint clean on the changed file (`php -l inc/frontend-chat.php`).
- Traced end-to-end: a roadie frontend chat now sends `modes [chat, roadie]` and a populated `client_context`; the roadie mode guidance (`inc/agent-mode/register.php`) composes on top of chat; the slug guard keeps non-roadie/non-frontend callers unaffected.
- No full runtime test (no deploy) — verification is by code trace through `AgentsChatHandler::resolveModes` (reads `$input['modes']`), `AgentModeDirective` (`datamachine_agent_mode_{$mode}`), and `ClientContextDirective` (renders each `client_context` key).