### PR TITLE
fix(homeboy): use host-smoke test backend for standalone smoke tests

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -5,7 +5,7 @@
   "extensions": {
     "wordpress": {
       "settings": {
-        "test_backend": "host"
+				"test_backend": "host-smoke"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Change `homeboy.json` `test_backend` from `host` → **`host-smoke`**.

## Why
roadie ships **only standalone smoke tests** (`tests/**/*-smoke.php` with `_stub-*.php` mocks — no real WordPress/DB). The `host-smoke` backend is the homeboy WordPress-extension backend purpose-built for exactly this.

`host` is **not a valid WordPress-extension backend** — there is no `test-runner-host.sh`; the supported backends are `playground`, `host-smoke`, `core-dev`. With `host` set, the dispatcher silently fell through to the `playground` default (`test-runner.sh:49`), which boots wp-phpunit + SQLite and activates roadie's `data-machine` dependency. Data Machine's activation hook writes `datamachine_settings` to `wptests_options`, which crashes the run (`SQLSTATE[42S02]: Table 'wptests_options' doesn't exist` during plugin activation). That failed the release preflight `test` step and blocked tagging — the last roadie deploy had to use `--head`.

## Verification
With `host-smoke`, all roadie smoke suites pass:
```
Backend: host-smoke
✓ agent-mode-registration-smoke (14 assertions)
✓ calling-user-identity-smoke (12 assertions)
✓ calling-user-permission-denial-smoke (28 assertions)
✓ frontend-chat-branding-smoke (3 assertions)
HOST_SMOKE_SUMMARY: passed=4 failed=0 → status: passed
```

## Impact
Roadie releases will tag cleanly going forward (no more `--head` deploys). No production code change — purely the release/test pipeline config.

## Related
A companion homeboy-extensions issue tracks the underlying tooling bug: an invalid `test_backend` value should hard-fail with the list of valid backends, not silently fall back to `playground`.