### PR TITLE
feat: role-aware roadie chat surface (public/team/admin)

### DIFF
--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -59,11 +59,19 @@ add_action(
  *
  * The filter callback receives the current directive content and the full
  * invocation payload. We append a focused mode guidance block that explains
- * the EC platform topology, available tool domains, calling-user contract,
- * editorial voice, and operating posture for any agent acting through the
- * Roadie tool surface.
+ * the EC platform topology, the tool domains available *to this caller*, the
+ * calling-user contract, editorial voice, and operating posture.
+ *
+ * The guidance is **role-aware**: the network topology, cross-site
+ * conventions, and editorial voice are shared across all tiers, but the
+ * available-tools section, the operating posture, and the identity block vary
+ * by the caller's role tier (public / team / admin) as resolved by
+ * extrachill_roadie_user_tier(). This keeps a public visitor from being told
+ * about management tools they cannot use, while giving team/admin callers the
+ * full manual. One function, DRY shared sections, branch on tier.
  *
  * @since 0.8.0
+ * @since 0.10.0 Role-aware: guidance body varies by caller tier.
  *
  * @param string $content Current directive content for the roadie mode.
  * @param array  $payload Full AI invocation payload.
@@ -79,18 +87,85 @@ function extrachill_roadie_mode_guidance( string $content, array $payload ): str
 		$calling_user_id = max( 0, (int) $payload['calling_user_id'] );
 	}
 
-	$identity_line = $calling_user_id > 0
-		? sprintf(
-			'You are responding to a request from user #%d. Tools that take a `user_id` input default to this user when the input is omitted.',
-			$calling_user_id
-		)
-		: 'There is no human caller for this invocation (system task, scheduled job, or background pipeline). Tools that need a `user_id` will not have a default — supply one explicitly or skip user-scoped actions.';
+	$tier = function_exists( 'extrachill_roadie_user_tier' )
+		? extrachill_roadie_user_tier( $calling_user_id )
+		: EXTRACHILL_ROADIE_TIER_PUBLIC;
 
-	$guidance = <<<MD
-# Extra Chill Platform Context
+	$guidance = extrachill_roadie_compose_guidance( $tier, $calling_user_id );
 
-This context is active when you operate against the Extra Chill multisite network — a publication and community platform for independent music. You have a tool surface for managing artist profiles, link pages, user profiles, and the community forum.
+	if ( '' === trim( $content ) ) {
+		return $guidance;
+	}
 
+	return $content . "\n\n" . $guidance;
+}
+
+/**
+ * Compose the full mode guidance body for a given role tier.
+ *
+ * Assembles shared sections (topology, cross-site conventions, editorial
+ * voice) with the tier-specific sections (available tools, identity contract,
+ * operating posture). The shared sections are authored once and reused; only
+ * the variable sections branch on tier.
+ *
+ * @since 0.10.0
+ *
+ * @param string $tier            Role tier: `public`, `team`, or `admin`.
+ * @param int    $calling_user_id Resolved calling user ID (0 = no human caller).
+ * @return string Composed guidance markdown.
+ */
+function extrachill_roadie_compose_guidance( string $tier, int $calling_user_id ): string {
+	$topology = extrachill_roadie_guidance_topology();
+	$voice    = extrachill_roadie_guidance_editorial_voice();
+
+	if ( EXTRACHILL_ROADIE_TIER_PUBLIC === $tier ) {
+		$intro    = 'This context is active when you operate against the Extra Chill multisite network — a publication and community platform for independent music. You are talking to a **visitor** (not signed in, or signed in without an Extra Chill team account). Help them explore and point them toward signing in when they want to manage their own stuff.';
+		$tools    = extrachill_roadie_guidance_tools_public();
+		$identity = extrachill_roadie_guidance_identity_public();
+		$posture  = extrachill_roadie_guidance_posture_public();
+
+		return extrachill_roadie_assemble_guidance( $intro, $topology, $tools, $identity, $voice, $posture );
+	}
+
+	// Team and admin share the full platform manual; the identity contract and a
+	// short admin addendum are the only differences.
+	$intro = 'This context is active when you operate against the Extra Chill multisite network — a publication and community platform for independent music. You have a tool surface for managing artist profiles, link pages, user profiles, and the community forum.';
+	$tools = extrachill_roadie_guidance_tools_team( EXTRACHILL_ROADIE_TIER_ADMIN === $tier );
+
+	$identity = EXTRACHILL_ROADIE_TIER_ADMIN === $tier
+		? extrachill_roadie_guidance_identity_admin( $calling_user_id )
+		: extrachill_roadie_guidance_identity_team( $calling_user_id );
+
+	$posture = extrachill_roadie_guidance_posture_team();
+
+	return extrachill_roadie_assemble_guidance( $intro, $topology, $tools, $identity, $voice, $posture );
+}
+
+/**
+ * Assemble the guidance sections in canonical order.
+ *
+ * @since 0.10.0
+ *
+ * @param string $intro    Tier-specific intro line.
+ * @param string $topology Shared network-topology section.
+ * @param string $tools    Tier-specific available-tools section.
+ * @param string $identity Tier-specific identity-contract section.
+ * @param string $voice    Shared editorial-voice section.
+ * @param string $posture  Tier-specific operating-posture section.
+ * @return string
+ */
+function extrachill_roadie_assemble_guidance( string $intro, string $topology, string $tools, string $identity, string $voice, string $posture ): string {
+	return "# Extra Chill Platform Context\n\n{$intro}\n\n{$topology}\n\n{$tools}\n\n{$identity}\n\n{$voice}\n\n{$posture}";
+}
+
+/**
+ * Shared: network topology + cross-site conventions.
+ *
+ * @since 0.10.0
+ * @return string
+ */
+function extrachill_roadie_guidance_topology(): string {
+	return <<<MD
 ## Network Topology
 
 Extra Chill runs as a WordPress multisite across nine subdomains. Identity (users, roles, capabilities) is network-wide; content is per-site. The tools handle cross-site routing internally via the `ec_cross_site_rest_request()` helper — you do not need to think about which site a request lands on.
@@ -105,30 +180,23 @@ Extra Chill runs as a WordPress multisite across nine subdomains. Identity (user
 - **wire.extrachill.com** — news wire
 - **studio.extrachill.com** — studio
 
-## Available Tool Domains
-
-- `manage_artist_profile` — list, get, create, and update artist profiles. Auto-resolves `artist_id` when the calling user manages exactly one artist.
-- `manage_link_page` — get, edit links, edit socials, edit styles, edit settings on an artist's public link page. Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save dance for you.
-- `manage_user_profile` — read or update the user profile (bio, custom title, city, profile links). Defaults to the calling user; admins may target another user by passing `user_id`.
-- `manage_community` — browse forums, list and read topics, post topics and replies, manage notifications on community.extrachill.com.
-
-Reach for the tool whose domain matches the request. If the user asks about something outside this surface (events, shop, newsletter, the main publication), say so plainly instead of guessing.
-
-## Calling-User Identity Contract
-
-{$identity_line}
-
-- When `user_id` is supplied explicitly to a tool, the tool acts on behalf of that user — but only if you have the capability. Non-admin agents cannot impersonate other users; the tool returns a clean permission error in that case.
-- The community tool (`manage_community`) attributes forum posts and replies to the calling user, not to the agent. Do not post on someone else's behalf without their request.
-- When there is no human caller (calling user is 0), avoid user-scoped writes. Read-only actions (lookups, listings) are fine.
-
 ## Cross-Site Conventions
 
 - Identity is network-wide — a user has the same ID and capabilities on every site.
 - Content lives on its origin site. The tools switch blogs internally; you do not.
 - Permissions are checked against the route's target site, not the site you happen to be calling from.
 - Cross-site reads via `switch_to_blog()` are safe; writes go through REST so capability checks run in the right context.
+MD;
+}
 
+/**
+ * Shared: editorial voice.
+ *
+ * @since 0.10.0
+ * @return string
+ */
+function extrachill_roadie_guidance_editorial_voice(): string {
+	return <<<MD
 ## Editorial Voice
 
 Extra Chill is an independent, grassroots music platform — not a corporate publication. When generating content (bios, topic posts, replies, profile copy):
@@ -137,7 +205,150 @@ Extra Chill is an independent, grassroots music platform — not a corporate pub
 - "Extra chill" — relaxed but focused.
 - Authentic, not promotional. Avoid marketing-speak, hype, and corporate filler.
 - Respect the user's voice. Suggest, don't overwrite.
+MD;
+}
 
+/**
+ * Public tier: available tools (explore only — no management tools offered).
+ *
+ * @since 0.10.0
+ * @return string
+ */
+function extrachill_roadie_guidance_tools_public(): string {
+	return <<<MD
+## What You Can Help With
+
+You are talking to a visitor, so you do **not** have the platform management tools right now — those unlock when an Extra Chill team member signs in. Keep it to exploring and explaining:
+
+- Help them understand what Extra Chill is: an independent music publication + community for independent artists and fans.
+- Point them to the right corner of the network for what they want (read the community forum, browse artist profiles, check out the news wire, the events calendar, the shop).
+- If they want to manage their **own** artist profile, link page, user profile, or post in the community, tell them to sign in with an Extra Chill account — those actions need a logged-in team member, and the tools appear once they do.
+
+Do not promise to perform management actions (creating/updating profiles, posting to the forum, filing feature requests, proposing code) — you cannot do those for a visitor. Be upfront and friendly about that boundary instead of attempting a tool you don't have.
+MD;
+}
+
+/**
+ * Team/admin tier: available tools (full platform management surface).
+ *
+ * @since 0.10.0
+ *
+ * @param bool $is_admin Whether to append the admin-only code-contribution note.
+ * @return string
+ */
+function extrachill_roadie_guidance_tools_team( bool $is_admin ): string {
+	$base = <<<MD
+## Available Tool Domains
+
+- `manage_artist_profile` — list, get, create, and update artist profiles. Auto-resolves `artist_id` when the calling user manages exactly one artist.
+- `manage_link_page` — get, edit links, edit socials, edit styles, edit settings on an artist's public link page. Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save dance for you.
+- `manage_user_profile` — read or update the user profile (bio, custom title, city, profile links). Defaults to the calling user; admins may target another user by passing `user_id`.
+- `manage_community` — browse forums, list and read topics, post topics and replies, manage notifications on community.extrachill.com.
+- `file_feature_request` — file a feature request as a GitHub issue when the user wants something the platform doesn't do yet.
+- `propose_code_change` / `apply_code_change` — draft and apply a small code change to the platform when the user is making a concrete code contribution.
+
+Reach for the tool whose domain matches the request. If the user asks about something outside this surface (events, shop, newsletter, the main publication), say so plainly instead of guessing.
+MD;
+
+	if ( ! $is_admin ) {
+		return $base;
+	}
+
+	return $base . "\n\nAs an administrator you have the full surface above with no per-tool restrictions.";
+}
+
+/**
+ * Public tier: identity contract.
+ *
+ * @since 0.10.0
+ * @return string
+ */
+function extrachill_roadie_guidance_identity_public(): string {
+	return <<<MD
+## Calling-User Identity Contract
+
+This is an unauthenticated (or non-team) visitor. There is no user context to act on behalf of, and no management tools are available. Keep everything read-only and conversational; for anything that would change platform data, point them to sign in.
+MD;
+}
+
+/**
+ * Team tier: identity contract.
+ *
+ * @since 0.10.0
+ *
+ * @param int $calling_user_id Resolved calling user ID.
+ * @return string
+ */
+function extrachill_roadie_guidance_identity_team( int $calling_user_id ): string {
+	$line = $calling_user_id > 0
+		? sprintf(
+			'You are responding to a request from user #%d. Tools that take a `user_id` input default to this user when the input is omitted.',
+			$calling_user_id
+		)
+		: 'There is no human caller for this invocation (system task, scheduled job, or background pipeline). Tools that need a `user_id` will not have a default — supply one explicitly or skip user-scoped actions.';
+
+	return <<<MD
+## Calling-User Identity Contract
+
+{$line}
+
+- Tools act on behalf of the calling user by default. You operate on **their** artist profiles, link pages, user profile, and community posts.
+- You cannot act on behalf of another user — that requires admin access. If you try, the tool returns a clean permission error.
+- The community tool (`manage_community`) attributes forum posts and replies to the calling user, not to the agent. Do not post without their request.
+MD;
+}
+
+/**
+ * Admin tier: identity contract (adds act-on-behalf-of note).
+ *
+ * @since 0.10.0
+ *
+ * @param int $calling_user_id Resolved calling user ID.
+ * @return string
+ */
+function extrachill_roadie_guidance_identity_admin( int $calling_user_id ): string {
+	$line = $calling_user_id > 0
+		? sprintf(
+			'You are responding to a request from administrator #%d. Tools that take a `user_id` input default to this user when the input is omitted.',
+			$calling_user_id
+		)
+		: 'There is no human caller for this invocation (system task, scheduled job, or background pipeline). Tools that need a `user_id` will not have a default — supply one explicitly or skip user-scoped actions.';
+
+	return <<<MD
+## Calling-User Identity Contract
+
+{$line}
+
+- You have administrator access. Tools default to the calling admin, but you **can target another user** by passing an explicit `user_id` to user-scoped tools (`manage_artist_profile`, `manage_link_page`, `manage_user_profile`). Use this only when the admin explicitly asks to act on someone else's behalf.
+- When acting on another user, name whose data you are changing so the action is auditable.
+- The community tool (`manage_community`) attributes forum posts and replies to the calling user. Do not post on someone else's behalf without an explicit request.
+MD;
+}
+
+/**
+ * Public tier: operating posture.
+ *
+ * @since 0.10.0
+ * @return string
+ */
+function extrachill_roadie_guidance_posture_public(): string {
+	return <<<MD
+## Operating Mode
+
+- **Be a helpful guide, not a doer.** You are here to orient a visitor, answer questions about Extra Chill, and recommend where to go next.
+- **Don't fake actions.** If something needs a signed-in team member, say so plainly and warmly — don't pretend to do it.
+- **Keep it short and music-forward.** Visitors are exploring; give them a reason to stick around.
+MD;
+}
+
+/**
+ * Team/admin tier: operating posture.
+ *
+ * @since 0.10.0
+ * @return string
+ */
+function extrachill_roadie_guidance_posture_team(): string {
+	return <<<MD
 ## Operating Mode
 
 - **Lookups and reads** — act immediately. The user expects fast answers.
@@ -145,10 +356,4 @@ Extra Chill is an independent, grassroots music platform — not a corporate pub
 - **Cite sources** — when you pull data from a tool result, reference what you saw (artist ID, topic ID, link section). This makes corrections cheap.
 - **Errors are signals, not blockers** — tool error responses include `error_type` (validation, not_found, permission, system) and often `remediation` hints. Read them and adjust; do not retry blindly.
 MD;
-
-	if ( '' === trim( $content ) ) {
-		return $guidance;
-	}
-
-	return $content . "\n\n" . $guidance;
 }

--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -165,7 +165,7 @@ function extrachill_roadie_assemble_guidance( string $intro, string $topology, s
  * @return string
  */
 function extrachill_roadie_guidance_topology(): string {
-	return <<<MD
+	return <<<'MD'
 ## Network Topology
 
 Extra Chill runs as a WordPress multisite across nine subdomains. Identity (users, roles, capabilities) is network-wide; content is per-site. The tools handle cross-site routing internally via the `ec_cross_site_rest_request()` helper — you do not need to think about which site a request lands on.
@@ -196,7 +196,7 @@ MD;
  * @return string
  */
 function extrachill_roadie_guidance_editorial_voice(): string {
-	return <<<MD
+	return <<<'MD'
 ## Editorial Voice
 
 Extra Chill is an independent, grassroots music platform — not a corporate publication. When generating content (bios, topic posts, replies, profile copy):
@@ -215,7 +215,7 @@ MD;
  * @return string
  */
 function extrachill_roadie_guidance_tools_public(): string {
-	return <<<MD
+	return <<<'MD'
 ## What You Can Help With
 
 You are talking to a visitor, so you do **not** have the platform management tools right now — those unlock when an Extra Chill team member signs in. Keep it to exploring and explaining:
@@ -237,7 +237,7 @@ MD;
  * @return string
  */
 function extrachill_roadie_guidance_tools_team( bool $is_admin ): string {
-	$base = <<<MD
+	$base = <<<'MD'
 ## Available Tool Domains
 
 - `manage_artist_profile` — list, get, create, and update artist profiles. Auto-resolves `artist_id` when the calling user manages exactly one artist.
@@ -264,7 +264,7 @@ MD;
  * @return string
  */
 function extrachill_roadie_guidance_identity_public(): string {
-	return <<<MD
+	return <<<'MD'
 ## Calling-User Identity Contract
 
 This is an unauthenticated (or non-team) visitor. There is no user context to act on behalf of, and no management tools are available. Keep everything read-only and conversational; for anything that would change platform data, point them to sign in.
@@ -332,7 +332,7 @@ MD;
  * @return string
  */
 function extrachill_roadie_guidance_posture_public(): string {
-	return <<<MD
+	return <<<'MD'
 ## Operating Mode
 
 - **Be a helpful guide, not a doer.** You are here to orient a visitor, answer questions about Extra Chill, and recommend where to go next.
@@ -348,7 +348,7 @@ MD;
  * @return string
  */
 function extrachill_roadie_guidance_posture_team(): string {
-	return <<<MD
+	return <<<'MD'
 ## Operating Mode
 
 - **Lookups and reads** — act immediately. The user expects fast answers.

--- a/inc/frontend-chat.php
+++ b/inc/frontend-chat.php
@@ -23,6 +23,17 @@ function extrachill_roadie_frontend_chat_config( array $config ): array {
 
 	$config['fab_label'] = EXTRACHILL_ROADIE_AGENT_NAME;
 
+	// Role-aware greeting: signed-in team/admin callers get the working-assistant
+	// framing; logged-out visitors get an explore-oriented nudge that matches the
+	// public-tier guidance + tool surface. Keyed on login state only (the FAB is
+	// rendered before any chat turn, so the per-turn calling_user_id isn't yet
+	// available here) — this is the cheap, correct signal for the launcher label.
+	if ( ! is_user_logged_in() ) {
+		$config['fab_greeting'] = __( 'New here? Ask me about Extra Chill — or sign in to manage your profile.', 'extrachill-roadie' );
+	} else {
+		$config['fab_greeting'] = __( 'Hey — what can I help you with on Extra Chill?', 'extrachill-roadie' );
+	}
+
 	// Suppress the generic "AI" leading-icon label; Roadie ships with no FAB icon yet.
 	// When a Roadie brand mark is ready, set this to an SVG path string instead.
 	$config['fab_icon'] = '';

--- a/inc/permissions.php
+++ b/inc/permissions.php
@@ -23,6 +23,65 @@ const EXTRACHILL_ROADIE_AGENT_SLUG = 'roadie';
 const EXTRACHILL_ROADIE_AGENT_NAME = 'Roadie';
 
 /**
+ * Role tier: public visitor (logged out, or no team capability).
+ */
+const EXTRACHILL_ROADIE_TIER_PUBLIC = 'public';
+
+/**
+ * Role tier: Extra Chill team member (`access_roadie` / `extra_chill_team`).
+ */
+const EXTRACHILL_ROADIE_TIER_TEAM = 'team';
+
+/**
+ * Role tier: administrator (`manage_options`).
+ */
+const EXTRACHILL_ROADIE_TIER_ADMIN = 'admin';
+
+/**
+ * Resolve a user's Roadie role tier.
+ *
+ * This is the ONE auditable capability→tier mapping for the whole Roadie
+ * surface. The role-aware guidance (inc/agent-mode/register.php) and the
+ * per-tier tool-visibility filter (inc/tools/register.php) both consume it,
+ * so the tier boundaries live in exactly one place.
+ *
+ * Tiers (highest wins):
+ *   - `admin`  — `manage_options`. Everything, plus acting on behalf of other
+ *                users via an explicit `user_id`.
+ *   - `team`   — `access_roadie` (granted by the `extra_chill_team` role on
+ *                every site; extrachill-users#45). Full platform management
+ *                tool surface + code-contribution actions.
+ *   - `public` — everyone else (logged out, or a logged-in user without team
+ *                access). Explore/guidance only; no management tools offered.
+ *
+ * A user_id of 0 (no human caller — system task, scheduled job, background
+ * pipeline) resolves to `public`: there is no authenticated actor to grant
+ * the team/admin surface to, and user-scoped writes are inappropriate without
+ * a caller. System tasks reach abilities directly with their own gates.
+ *
+ * @since 0.10.0
+ *
+ * @param int $user_id User ID to resolve. 0 means "no human caller".
+ * @return string One of `public`, `team`, `admin`.
+ */
+function extrachill_roadie_user_tier( int $user_id ): string {
+	if ( $user_id <= 0 ) {
+		return EXTRACHILL_ROADIE_TIER_PUBLIC;
+	}
+
+	if ( user_can( $user_id, 'manage_options' ) ) {
+		return EXTRACHILL_ROADIE_TIER_ADMIN;
+	}
+
+	// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom cap granted by the extra_chill_team role (extrachill-users#45).
+	if ( user_can( $user_id, 'access_roadie' ) ) {
+		return EXTRACHILL_ROADIE_TIER_TEAM;
+	}
+
+	return EXTRACHILL_ROADIE_TIER_PUBLIC;
+}
+
+/**
  * Resolve redirect URIs allowed for browser-based bridge auth.
  *
  * Keep this explicit and auditable. Same-site callbacks are already allowed by

--- a/inc/tools/register.php
+++ b/inc/tools/register.php
@@ -48,3 +48,89 @@ add_action(
 		new ECRoadie_FileFeatureRequest();
 	}
 );
+
+/**
+ * The roadie platform management tools, by slug.
+ *
+ * These are the seven write-capable tools registered above. They are the set
+ * hidden from public-tier callers — a visitor with no team access cannot use
+ * any of them, so offering them only produces dead options and permission-error
+ * round-trips.
+ *
+ * @since 0.10.0
+ * @return string[]
+ */
+function extrachill_roadie_managed_tool_slugs(): array {
+	return array(
+		'manage_artist_profile',
+		'manage_link_page',
+		'manage_user_profile',
+		'manage_community',
+		'propose_code_change',
+		'apply_code_change',
+		'file_feature_request',
+	);
+}
+
+/**
+ * Hide roadie management tools from public-tier callers.
+ *
+ * Per-call execution gating already exists in ECRoadie_PlatformTool (a public
+ * user gets a clean permission error), but the tools are still *offered* to the
+ * model — cluttering the prompt with options a visitor can never use. This
+ * filter removes them from the exposed tool set for public-tier callers so the
+ * surface matches the role-aware guidance.
+ *
+ * Uses Data Machine's `datamachine_resolved_tools` filter — the canonical
+ * per-request, post-policy tool-visibility seam. It fires once per chat turn
+ * with the resolved tool set plus the resolution `$args`, which carry the
+ * `calling_user_id` threaded through from the chat orchestrator. No new infra:
+ * we resolve the caller's tier via extrachill_roadie_user_tier() (the same
+ * mapping the guidance uses) and unset the management tools for `public`.
+ *
+ * Team and admin callers are unaffected — they keep the full surface and rely
+ * on the existing per-call gates for fine-grained checks (e.g. acting on
+ * behalf of another user is still admin-only at execution time).
+ *
+ * Only acts when the `roadie` mode is active, so non-roadie chat surfaces that
+ * happen to share the resolver are untouched.
+ *
+ * @since 0.10.0
+ *
+ * @param array        $tools Resolved tools keyed by tool name.
+ * @param string|array $mode  Active mode slug, or array of mode slugs.
+ * @param array        $args  Resolution args (carries `calling_user_id`).
+ * @return array Filtered tools.
+ */
+function extrachill_roadie_filter_tools_by_tier( $tools, $mode, array $args ): array {
+	if ( ! is_array( $tools ) ) {
+		return is_array( $tools ) ? $tools : array();
+	}
+
+	// Only act when the roadie mode is part of this turn.
+	$modes = is_array( $mode ) ? $mode : array( $mode );
+	if ( ! in_array( EXTRACHILL_ROADIE_AGENT_SLUG, array_map( 'strval', $modes ), true ) ) {
+		return $tools;
+	}
+
+	if ( ! function_exists( 'extrachill_roadie_user_tier' ) ) {
+		return $tools;
+	}
+
+	$calling_user_id = 0;
+	if ( isset( $args['calling_user_id'] ) && is_numeric( $args['calling_user_id'] ) ) {
+		$calling_user_id = max( 0, (int) $args['calling_user_id'] );
+	}
+
+	// Team and admin keep the full surface.
+	if ( EXTRACHILL_ROADIE_TIER_PUBLIC !== extrachill_roadie_user_tier( $calling_user_id ) ) {
+		return $tools;
+	}
+
+	foreach ( extrachill_roadie_managed_tool_slugs() as $slug ) {
+		unset( $tools[ $slug ] );
+	}
+
+	return $tools;
+}
+add_filter( 'datamachine_resolved_tools', 'extrachill_roadie_filter_tools_by_tier', 10, 3 );


### PR DESCRIPTION
## Summary

Makes the Roadie chat surface **role-aware** — public visitors, team members, and admins each get a different tool set, different guidance, and a login-aware greeting. Built entirely on **existing seams; no new infrastructure**.

Closes #32 (guidance + tool-visibility **both implemented** — see below).

## Tier mapping (one auditable place)

New `extrachill_roadie_user_tier( int $user_id ): string` in `inc/permissions.php` is the single capability→tier mapping. Both the guidance and the tool-visibility filter consume it.

| Tier | Cap signal | Resolved when |
|------|-----------|---------------|
| `admin` | `manage_options` | admin caller |
| `team` | `access_roadie` (granted by `extra_chill_team`) | team caller |
| `public` | none / logged out / `user_id` 0 | everyone else, incl. system tasks |

`user_id` 0 (no human caller — system task / scheduled job / pipeline) resolves to `public`: no authenticated actor to grant the management surface to.

## What varies per role

**1. Guidance** (`extrachill_roadie_mode_guidance()`, `inc/agent-mode/register.php`)
DRY refactor: shared sections (network topology, cross-site conventions, editorial voice) are authored once and reused; the variable sections branch on tier:

- **Public** → explore-only block ("here's what Extra Chill is; sign in to manage your own stuff"), no tool domains, guide-not-doer posture.
- **Team** → full platform manual (all tool domains incl. code-contribution), default-to-calling-user identity contract.
- **Admin** → full manual **plus** the "you can target another user via `user_id`" note.

**2. Tool visibility** (IMPLEMENTED — clean seam found)
Investigated DM core: `ToolPolicyResolver::resolve()` fires `datamachine_resolved_tools` (`$tools, $mode, $args`) once per turn after policy resolution, and `$args` carries `calling_user_id` threaded from `ChatOrchestrator::resolveToolsForChat()`. That is the canonical per-request, post-policy visibility seam — no new infra needed.

New `extrachill_roadie_filter_tools_by_tier()` hooks it and, **only when the `roadie` mode is active**, strips the seven management tools (`manage_artist_profile`, `manage_link_page`, `manage_user_profile`, `manage_community`, `propose_code_change`, `apply_code_change`, `file_feature_request`) for **public-tier** callers. Team/admin keep the full surface; existing per-call execution gates in `ECRoadie_PlatformTool` are untouched (defense in depth).

**3. FAB greeting** (`inc/frontend-chat.php`)
Varies the launcher greeting by login state via the existing `fab_greeting` config key (verified it's a real key in `frontend-agent-chat`, defaults to `''`) — explore nudge for logged-out, working-assistant framing for logged-in.

## Verification

- `homeboy lint extrachill-roadie` → **exit 0, no findings**. `php -l` clean on all 4 files.
- **Tier trace** (standalone harness, stubbed `user_can`):

| Tier | guidance: explore / toolDomains / adminNote | tools after filter |
|------|--------------------------------------------|--------------------|
| public (logged out, uid 0) | Y / N / N | management tools stripped |
| public (logged in, no team) | Y / N / N | management tools stripped |
| team | N / Y / N | all 7 visible |
| admin | N / Y / **Y** | all 7 visible |

- `git diff origin/main --name-only` → only `inc/agent-mode/register.php`, `inc/frontend-chat.php`, `inc/permissions.php`, `inc/tools/register.php`. **`docs/CHANGELOG.md` NOT touched; no version bump.**

## Notes

- `@since 0.10.0` tags on new code (current release is 0.9.0; homeboy owns the actual bump from the conventional commit).
- Per-role **choices** (issue item tying to #31's `present_question`) are out of scope here — that lands when #31's question tool is wired; this PR covers guidance + tool-visibility + greeting.