### PR TITLE
feat: add present_question tool for multiple-choice question cards

### DIFF
--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -338,6 +338,7 @@ function extrachill_roadie_guidance_posture_public(): string {
 - **Be a helpful guide, not a doer.** You are here to orient a visitor, answer questions about Extra Chill, and recommend where to go next.
 - **Don't fake actions.** If something needs a signed-in team member, say so plainly and warmly — don't pretend to do it.
 - **Keep it short and music-forward.** Visitors are exploring; give them a reason to stick around.
+- **Branching choices** — when the next step is a pick from a small, well-defined set of options, call `present_question` to render clickable choices instead of asking an open-ended question.
 MD;
 }
 
@@ -355,5 +356,6 @@ function extrachill_roadie_guidance_posture_team(): string {
 - **Content changes** — propose then act. Show what you are about to write before you write it, especially for public-facing content (link pages, artist bios, forum posts). One short proposal is enough; do not over-explain.
 - **Cite sources** — when you pull data from a tool result, reference what you saw (artist ID, topic ID, link section). This makes corrections cheap.
 - **Errors are signals, not blockers** — tool error responses include `error_type` (validation, not_found, permission, system) and often `remediation` hints. Read them and adjust; do not retry blindly.
+- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. Reserve open-ended questions for genuinely free-form input.
 MD;
 }

--- a/inc/tools/class-present-question.php
+++ b/inc/tools/class-present-question.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Present Question Tool
+ *
+ * Presentational chat tool that lets the agent surface a multiple-choice
+ * question to the user as an interactive card. Instead of asking an
+ * open-ended question and parsing a free-text reply, the agent calls
+ * `present_question` with a question string and a small set of choices;
+ * the frontend chat renders each choice as a clickable button. Clicking a
+ * choice sends its `message` back to the agent as a normal user turn, so
+ * the round-trip is automatic and the agent gets a clean, unambiguous answer.
+ *
+ * This is a pure presentational tool — it performs no cross-site calls and
+ * needs no capability gate beyond being offered in the chat surface. It simply
+ * echoes the question and choices back under a `result` key so the chat
+ * package's tool-name-agnostic QuestionCard renderer (keyed on the
+ * `present_question` tool name) can render them.
+ *
+ * Result contract consumed by the renderer:
+ *   array(
+ *     'result' => array(
+ *       'question' => '...',
+ *       'choices'  => array(
+ *         array( 'label' => '...', 'message' => '...', 'description' => '...' ),
+ *         ...
+ *       ),
+ *     ),
+ *   )
+ *
+ * @package ExtraChillRoadie\Tools
+ * @since 0.11.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+
+class ECRoadie_PresentQuestion extends BaseTool {
+
+	protected string $tool_slug = 'present_question';
+
+	public function __construct() {
+		$this->registerTool(
+			$this->tool_slug,
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'access_level' => 'public' )
+		);
+	}
+
+	/**
+	 * Tool definition.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Present the user with a multiple-choice question rendered as clickable buttons. Use this whenever you need the user to pick from a small, well-defined set of options (a branching choice) instead of asking an open-ended question. Each choice has a short button label and the message that will be sent back as the user\'s reply when they click it. Clicking a choice continues the conversation automatically. Prefer this over free-text questions whenever the answer is genuinely one of a few discrete options.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'question', 'choices' ),
+				'properties' => array(
+					'question'       => array(
+						'type'        => 'string',
+						'description' => 'The question to present to the user. A single, clear prompt.',
+					),
+					'choices'        => array(
+						'type'        => 'array',
+						'description' => 'The available choices, in display order. Keep it to a handful of clear, mutually-exclusive options.',
+						'items'       => array(
+							'type'       => 'object',
+							'required'   => array( 'label', 'message' ),
+							'properties' => array(
+								'label'       => array(
+									'type'        => 'string',
+									'description' => 'Short button text shown to the user (e.g. "Yes, proceed").',
+								),
+								'message'     => array(
+									'type'        => 'string',
+									'description' => 'The message sent back as the user\'s reply when this choice is clicked. Phrase it as the user speaking (e.g. "Yes, go ahead and update my bio.").',
+								),
+								'description' => array(
+									'type'        => 'string',
+									'description' => 'Optional longer explanation of what this choice means, shown alongside the button.',
+								),
+							),
+						),
+					),
+					'allow_freeform' => array(
+						'type'        => 'boolean',
+						'description' => 'Optional. When true, signals the UI may also offer a free-text answer alongside the choices.',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tool callback.
+	 *
+	 * Validates the question and choices, then echoes them back under a
+	 * `result` key for the QuestionCard renderer. No side effects.
+	 *
+	 * @param array<string,mixed> $parameters Tool parameters.
+	 * @param array<string,mixed> $tool_def   Resolved tool definition (unused).
+	 * @return array<string,mixed>
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		unset( $tool_def );
+
+		$question = trim( (string) ( $parameters['question'] ?? '' ) );
+		if ( '' === $question ) {
+			return $this->buildErrorResponse(
+				'question is required and must be a non-empty string.',
+				$this->tool_slug
+			);
+		}
+
+		$raw_choices = $parameters['choices'] ?? null;
+		if ( ! is_array( $raw_choices ) || array() === $raw_choices ) {
+			return $this->buildErrorResponse(
+				'choices is required and must be a non-empty array of {label, message, description?} objects.',
+				$this->tool_slug
+			);
+		}
+
+		$choices = array();
+		foreach ( $raw_choices as $choice ) {
+			if ( ! is_array( $choice ) ) {
+				continue;
+			}
+
+			$label = trim( (string) ( $choice['label'] ?? '' ) );
+			if ( '' === $label ) {
+				return $this->buildErrorResponse(
+					'Each choice requires a non-empty label.',
+					$this->tool_slug
+				);
+			}
+
+			// Fall back to the label when no explicit reply message is given,
+			// so a click always sends something meaningful back.
+			$message = trim( (string) ( $choice['message'] ?? '' ) );
+			if ( '' === $message ) {
+				$message = $label;
+			}
+
+			$entry = array(
+				'label'   => $label,
+				'message' => $message,
+			);
+
+			$description = trim( (string) ( $choice['description'] ?? '' ) );
+			if ( '' !== $description ) {
+				$entry['description'] = $description;
+			}
+
+			$choices[] = $entry;
+		}
+
+		if ( array() === $choices ) {
+			return $this->buildErrorResponse(
+				'No valid choices provided. Each choice needs at least a label.',
+				$this->tool_slug
+			);
+		}
+
+		$result = array(
+			'question' => $question,
+			'choices'  => $choices,
+		);
+
+		if ( isset( $parameters['allow_freeform'] ) ) {
+			$result['allow_freeform'] = (bool) $parameters['allow_freeform'];
+		}
+
+		return array(
+			'result' => $result,
+		);
+	}
+}

--- a/inc/tools/register.php
+++ b/inc/tools/register.php
@@ -38,6 +38,7 @@ add_action(
 		require_once __DIR__ . '/class-propose-code-change.php';
 		require_once __DIR__ . '/class-apply-code-change.php';
 		require_once __DIR__ . '/class-file-feature-request.php';
+		require_once __DIR__ . '/class-present-question.php';
 
 		new ECRoadie_ManageArtistProfile();
 		new ECRoadie_ManageLinkPage();
@@ -46,6 +47,7 @@ add_action(
 		new ECRoadie_ProposeCodeChange();
 		new ECRoadie_ApplyCodeChange();
 		new ECRoadie_FileFeatureRequest();
+		new ECRoadie_PresentQuestion();
 	}
 );
 


### PR DESCRIPTION
## Summary
- Adds `ECRoadie_PresentQuestion` (`inc/tools/class-present-question.php`), a presentational chat tool named `present_question` that lets the agent surface a multiple-choice question rendered as clickable buttons in the frontend chat.
- The tool validates `question` (non-empty) + `choices` (non-empty array of `{label, message, description?}`) and echoes them back under a `result` key so the chat package's tool-name-agnostic `QuestionCard` renderer can render them. Clicking a choice sends `choice.message` back as a normal user turn — the round-trip is automatic.
- Pure presentational: **no** cross-site calls and **no** capability gate beyond being offered in the chat surface.
- Registered alongside the other platform tools in `inc/tools/register.php`, and documented in the roadie mode guidance (`inc/agent-mode/register.php`, team + public posture) so the agent prefers it over open-ended questions for branching choices.

## Renderer dependency
Relies on the generic `present_question` renderer key added in **frontend-agent-chat PR #63** (https://github.com/Extra-Chill/frontend-agent-chat/pull/63). That PR maps the `present_question` tool name to the existing `renderQuestionCard` renderer.

## Verification
- `php -l` clean on all three touched files.
- `homeboy lint` passes (exit 0, no findings).
- `git diff origin/main --name-only` shows only the three intended files; no `docs/CHANGELOG.md`, no version bump.

Closes #31