### PR TITLE
fix: infer GitHub repo from subsite context + route issue requests to file_feature_request

### DIFF
--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -244,10 +244,12 @@ function extrachill_roadie_guidance_tools_team( bool $is_admin ): string {
 - `manage_link_page` — get, edit links, edit socials, edit styles, edit settings on an artist's public link page. Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save dance for you.
 - `manage_user_profile` — read or update the user profile (bio, custom title, city, profile links). Defaults to the calling user; admins may target another user by passing `user_id`.
 - `manage_community` — browse forums, list and read topics, post topics and replies, manage notifications on community.extrachill.com.
-- `file_feature_request` — file a feature request as a GitHub issue when the user wants something the platform doesn't do yet.
+- `file_feature_request` — file or look up a **GitHub issue** against the right Extra Chill repo. This is the tool for ANY "open an issue on github" / "file an issue" / "report a bug" request, whether it's a feature request (something the platform doesn't do yet) OR a bug report (something broken, frozen, or misbehaving). The target `repo` is auto-inferred from the current subsite — when the user is on the subsite that owns the code (e.g. events.extrachill.com → `Extra-Chill/extrachill-events`), do NOT interrogate them for the repo; file it and confirm the inferred repo once.
 - `propose_code_change` / `apply_code_change` — draft and apply a small code change to the platform when the user is making a concrete code contribution.
 
 Reach for the tool whose domain matches the request. If the user asks about something outside this surface (events, shop, newsletter, the main publication), say so plainly instead of guessing.
+
+**Issue/bug routing:** when the user says "issue," "github," "file a bug," or "report a bug," route to `file_feature_request` — **never** `create_taxonomy_term` (that creates a category/tag term, not a GitHub issue, and is the wrong tool for tracking work).
 MD;
 
 	if ( ! $is_admin ) {

--- a/inc/contribute-code/repo-map.php
+++ b/inc/contribute-code/repo-map.php
@@ -239,6 +239,33 @@ function extrachill_roadie_default_repo_map(): array {
 }
 
 /**
+ * Resolve a component slug to its `owner/name` GitHub repo.
+ *
+ * Thin lookup over the slug-to-repo registry so callers (e.g. the
+ * file_feature_request repo-inference path) don't duplicate the registry or
+ * re-implement the slug → repo mapping. Returns an empty string when the slug
+ * is not registered.
+ *
+ * @since 0.11.0
+ *
+ * @param string $slug Component slug as it appears on disk under wp-content/.
+ * @return string `owner/name` repo, or empty string when the slug is unknown.
+ */
+function extrachill_roadie_repo_for_slug( string $slug ): string {
+	$slug = trim( $slug );
+	if ( '' === $slug ) {
+		return '';
+	}
+
+	$map = extrachill_roadie_default_repo_map();
+	if ( ! isset( $map[ $slug ] ) ) {
+		return '';
+	}
+
+	return (string) ( $map[ $slug ]['repo'] ?? '' );
+}
+
+/**
  * Get the canonical list of agent-stack plugin slugs (read-only mounts).
  *
  * Pulled from the repo map by filtering on `kind === 'agent-stack-plugin'`.

--- a/inc/tools/class-file-feature-request.php
+++ b/inc/tools/class-file-feature-request.php
@@ -68,10 +68,10 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 		return array(
 			'class'       => self::class,
 			'method'      => 'handle_tool_call',
-			'description' => 'When the user describes an idea, feature request, or bug observation that should be tracked (rather than implemented right now), use this tool to file or look up GitHub issues against the appropriate Extra Chill repo. Three actions are supported: action="file_issue" creates a new issue (requires repo, title, body); action="list_recent_issues" finds existing open issues to dedupe against (requires repo, optional labels/state); action="comment_on_issue" adds a comment to an existing issue (requires repo, issue_number, body). Before filing new issues, prefer calling list_recent_issues first with a few keywords from the proposed title to surface duplicates and ask the user whether to comment on an existing thread instead. Use propose_code_change instead when the user wants the change implemented, not just tracked.',
+			'description' => 'When the user wants to track something on GitHub — a feature request, a bug report, or any "open an issue on github" / "file an issue" / "report a bug" ask — use this tool to file or look up GitHub issues against the appropriate Extra Chill repo. This is ALWAYS the right tool for filing GitHub issues; never use create_taxonomy_term (which makes a category/tag term, not a GitHub issue) for issue/bug-report requests. Three actions are supported: action="file_issue" creates a new issue (requires title, body; repo is optional and auto-inferred from the current subsite when omitted); action="list_recent_issues" finds existing open issues to dedupe against (optional repo/labels/state); action="comment_on_issue" adds a comment to an existing issue (requires issue_number, body; repo optional). When the user is chatting from the subsite that owns the code, leave repo unset and it will be inferred from page context — do not interrogate the user for the repo. Before filing new issues, prefer calling list_recent_issues first with a few keywords from the proposed title to surface duplicates and ask the user whether to comment on an existing thread instead. Use propose_code_change instead when the user wants the change implemented, not just tracked.',
 			'parameters'  => array(
 				'type'       => 'object',
-				'required'   => array( 'action', 'repo' ),
+				'required'   => array( 'action' ),
 				'properties' => array(
 					'action'       => array(
 						'type'        => 'string',
@@ -80,7 +80,7 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 					),
 					'repo'         => array(
 						'type'        => 'string',
-						'description' => 'GitHub repo in owner/name form (e.g. Extra-Chill/extrachill-roadie). Must be present in the slug-to-repo registry; cross-org repos are rejected.',
+						'description' => 'GitHub repo in owner/name form (e.g. Extra-Chill/extrachill-roadie). Optional: when omitted, it is auto-inferred from the current subsite via the slug-to-repo registry. Must be present in the registry; cross-org repos are rejected.',
 					),
 					'title'        => array(
 						'type'        => 'string',
@@ -150,14 +150,28 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			);
 		}
 
-		// 3. Validate repo against the slug-to-repo registry.
-		$repo  = trim( (string) ( $parameters['repo'] ?? '' ) );
+		// 3. Resolve repo: prefer the explicit param, otherwise infer it from
+		// the current subsite's context so a team member chatting from
+		// e.g. events.extrachill.com doesn't have to name the repo.
+		$repo          = trim( (string) ( $parameters['repo'] ?? '' ) );
+		$repo_inferred = false;
+		if ( '' === $repo ) {
+			$inferred = $this->infer_repo_from_context();
+			if ( '' !== $inferred ) {
+				$repo          = $inferred;
+				$repo_inferred = true;
+			}
+		}
+
+		// 4. Validate repo against the slug-to-repo registry. Inference failure
+		// falls through to here, which returns the standard "repo is required"
+		// error so the model knows to supply one explicitly.
 		$check = $this->validate_repo( $repo );
 		if ( true !== $check ) {
 			return $check;
 		}
 
-		// 4. Verify abilities API + the specific ability we need.
+		// 5. Verify abilities API + the specific ability we need.
 		$ability_check = $this->require_ability( $this->ability_for_action( $action ) );
 		if ( true !== $ability_check ) {
 			return $ability_check;
@@ -165,11 +179,11 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 
 		switch ( $action ) {
 			case 'file_issue':
-				return $this->handle_file_issue( $parameters, $repo );
+				return $this->handle_file_issue( $parameters, $repo, $repo_inferred );
 			case 'list_recent_issues':
-				return $this->handle_list_recent_issues( $parameters, $repo );
+				return $this->handle_list_recent_issues( $parameters, $repo, $repo_inferred );
 			case 'comment_on_issue':
-				return $this->handle_comment_on_issue( $parameters, $repo );
+				return $this->handle_comment_on_issue( $parameters, $repo, $repo_inferred );
 		}
 
 		// Unreachable — action is validated above. Defensive default.
@@ -269,6 +283,60 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	}
 
 	/**
+	 * Infer the target repo from the current subsite's context.
+	 *
+	 * The tool runs in the subsite request context, so the current blog tells
+	 * us which subsite the user is chatting from. We resolve that blog to its
+	 * subsite-specific theme/plugin slugs via
+	 * `extrachill_roadie_detect_subsite_context()` and map the most
+	 * subsite-specific slug to its `owner/name` repo through the shared
+	 * slug-to-repo registry (`extrachill_roadie_repo_for_slug()`).
+	 *
+	 * Resolution priority:
+	 *   1. A subsite-specific active plugin slug present in the registry —
+	 *      this is the plugin that owns the subsite's behavior (e.g.
+	 *      `extrachill-events` on events.extrachill.com). The detector already
+	 *      excludes network-wide platform boilerplate, so the remaining
+	 *      plugins are genuinely subsite-specific.
+	 *   2. The active theme slug present in the registry — fallback for sites
+	 *      whose distinguishing surface is the theme rather than a plugin.
+	 *
+	 * Returns an empty string when no subsite slug maps to a registered repo,
+	 * which lets the caller fall back to requiring an explicit `repo`.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @return string `owner/name` repo, or empty string when inference fails.
+	 */
+	protected function infer_repo_from_context(): string {
+		if ( ! function_exists( 'extrachill_roadie_detect_subsite_context' )
+			|| ! function_exists( 'extrachill_roadie_repo_for_slug' ) ) {
+			return '';
+		}
+
+		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$context = extrachill_roadie_detect_subsite_context( $blog_id > 0 ? $blog_id : null );
+
+		// 1. Prefer a subsite-specific active plugin that maps to a repo.
+		foreach ( (array) ( $context['plugins'] ?? array() ) as $plugin ) {
+			$slug = (string) ( $plugin['slug'] ?? '' );
+			$repo = extrachill_roadie_repo_for_slug( $slug );
+			if ( '' !== $repo ) {
+				return $repo;
+			}
+		}
+
+		// 2. Fall back to the active theme slug.
+		$theme_slug = (string) ( $context['theme']['slug'] ?? '' );
+		$repo       = extrachill_roadie_repo_for_slug( $theme_slug );
+		if ( '' !== $repo ) {
+			return $repo;
+		}
+
+		return '';
+	}
+
+	/**
 	 * Confirm an ability is loaded and callable.
 	 *
 	 * @param string $ability_name Fully qualified ability name.
@@ -299,11 +367,12 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	/**
 	 * file_issue handler.
 	 *
-	 * @param array<string,mixed> $parameters Tool parameters.
-	 * @param string              $repo       Validated repo.
+	 * @param array<string,mixed> $parameters    Tool parameters.
+	 * @param string              $repo          Validated repo.
+	 * @param bool                $repo_inferred Whether $repo was inferred from context.
 	 * @return array<string,mixed>
 	 */
-	protected function handle_file_issue( array $parameters, string $repo ): array {
+	protected function handle_file_issue( array $parameters, string $repo, bool $repo_inferred = false ): array {
 		$title = trim( (string) ( $parameters['title'] ?? '' ) );
 		$body  = (string) ( $parameters['body'] ?? '' );
 
@@ -387,13 +456,14 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			'success'   => true,
 			'tool_name' => $this->tool_slug,
 			'data'      => array(
-				'action'       => 'file_issue',
-				'repo'         => $repo,
-				'issue_number' => $issue_number,
-				'issue_url'    => $issue_url,
-				'labels'       => $labels,
-				'next_step'    => 'If this issue describes a code change rather than just an idea to track, offer to call propose_code_change next so a sandbox can implement it.',
-				'raw'          => $result,
+				'action'        => 'file_issue',
+				'repo'          => $repo,
+				'repo_inferred' => $repo_inferred,
+				'issue_number'  => $issue_number,
+				'issue_url'     => $issue_url,
+				'labels'        => $labels,
+				'next_step'     => 'If this issue describes a code change rather than just an idea to track, offer to call propose_code_change next so a sandbox can implement it.',
+				'raw'           => $result,
 			),
 		);
 	}
@@ -401,11 +471,12 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	/**
 	 * list_recent_issues handler.
 	 *
-	 * @param array<string,mixed> $parameters Tool parameters.
-	 * @param string              $repo       Validated repo.
+	 * @param array<string,mixed> $parameters    Tool parameters.
+	 * @param string              $repo          Validated repo.
+	 * @param bool                $repo_inferred Whether $repo was inferred from context.
 	 * @return array<string,mixed>
 	 */
-	protected function handle_list_recent_issues( array $parameters, string $repo ): array {
+	protected function handle_list_recent_issues( array $parameters, string $repo, bool $repo_inferred = false ): array {
 		$state    = (string) ( $parameters['state'] ?? 'open' );
 		if ( ! in_array( $state, array( 'open', 'closed', 'all' ), true ) ) {
 			$state = 'open';
@@ -470,13 +541,14 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			'success'   => true,
 			'tool_name' => $this->tool_slug,
 			'data'      => array(
-				'action'    => 'list_recent_issues',
-				'repo'      => $repo,
-				'state'     => $state,
-				'keywords'  => $keywords,
-				'count'     => count( $issues ),
-				'issues'    => $issues,
-				'next_step' => 'Compare each issue title against the user\'s intent (and any keywords echoed above). If any look like the same idea, propose commenting on that existing issue with comment_on_issue. Otherwise proceed to file_issue.',
+				'action'        => 'list_recent_issues',
+				'repo'          => $repo,
+				'repo_inferred' => $repo_inferred,
+				'state'         => $state,
+				'keywords'      => $keywords,
+				'count'         => count( $issues ),
+				'issues'        => $issues,
+				'next_step'     => 'Compare each issue title against the user\'s intent (and any keywords echoed above). If any look like the same idea, propose commenting on that existing issue with comment_on_issue. Otherwise proceed to file_issue.',
 			),
 		);
 	}
@@ -484,11 +556,12 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	/**
 	 * comment_on_issue handler.
 	 *
-	 * @param array<string,mixed> $parameters Tool parameters.
-	 * @param string              $repo       Validated repo.
+	 * @param array<string,mixed> $parameters    Tool parameters.
+	 * @param string              $repo          Validated repo.
+	 * @param bool                $repo_inferred Whether $repo was inferred from context.
 	 * @return array<string,mixed>
 	 */
-	protected function handle_comment_on_issue( array $parameters, string $repo ): array {
+	protected function handle_comment_on_issue( array $parameters, string $repo, bool $repo_inferred = false ): array {
 		$issue_number = (int) ( $parameters['issue_number'] ?? 0 );
 		if ( $issue_number <= 0 ) {
 			return $this->buildErrorResponse(
@@ -546,11 +619,12 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			'success'   => true,
 			'tool_name' => $this->tool_slug,
 			'data'      => array(
-				'action'       => 'comment_on_issue',
-				'repo'         => $repo,
-				'issue_number' => $issue_number,
-				'comment_url'  => $comment_url,
-				'raw'          => $result,
+				'action'        => 'comment_on_issue',
+				'repo'          => $repo,
+				'repo_inferred' => $repo_inferred,
+				'issue_number'  => $issue_number,
+				'comment_url'   => $comment_url,
+				'raw'           => $result,
 			),
 		);
 	}

--- a/tests/feature-request-tool.php
+++ b/tests/feature-request-tool.php
@@ -119,7 +119,7 @@ $definition = $tool->getToolDefinition();
 roadie_test_assert( 'handle_tool_call' === $definition['method'], 'tool dispatch method' );
 $required = $definition['parameters']['required'] ?? array();
 roadie_test_assert( in_array( 'action', $required, true ), 'definition requires action' );
-roadie_test_assert( in_array( 'repo', $required, true ), 'definition requires repo' );
+roadie_test_assert( ! in_array( 'repo', $required, true ), 'definition makes repo optional (auto-inferred from context)' );
 
 $action_enum = $definition['parameters']['properties']['action']['enum'] ?? array();
 roadie_test_assert( in_array( 'file_issue', $action_enum, true ), 'action enum includes file_issue' );
@@ -144,8 +144,22 @@ $GLOBALS['extrachill_roadie_test_state']['user_caps'][ EXTRACHILL_ROADIE_PROPOSE
 $bad_action = $tool->handle_tool_call( array( 'action' => 'delete_universe', 'repo' => 'Extra-Chill/extrachill-roadie' ) );
 roadie_test_assert( false === $bad_action['success'], 'unknown action must be rejected' );
 
+// Missing repo + inference fails (unknown blog: no subsite-specific plugins,
+// theme slug not in the registry) must fall back to requiring an explicit repo.
+$GLOBALS['extrachill_roadie_test_state']['theme'] = (function () {
+	$theme             = new ECRoadie_TestTheme();
+	$theme->stylesheet = 'some-unregistered-theme';
+	return $theme;
+})();
+$GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array();
 $missing_repo = $tool->handle_tool_call( array( 'action' => 'file_issue', 'repo' => '', 'title' => 't', 'body' => 'b' ) );
-roadie_test_assert( false === $missing_repo['success'], 'missing repo must be rejected' );
+roadie_test_assert( false === $missing_repo['success'], 'missing repo with failed inference must be rejected' );
+roadie_test_assert(
+	false !== strpos( $missing_repo['error'] ?? '', 'repo is required' ),
+	'failed-inference fallback surfaces the standard repo-required error'
+);
+// Restore the default registered theme for the rest of the suite.
+$GLOBALS['extrachill_roadie_test_state']['theme'] = null;
 
 $bad_repo = $tool->handle_tool_call( array( 'action' => 'file_issue', 'repo' => 'evil-org/private-secrets', 'title' => 't', 'body' => 'b' ) );
 roadie_test_assert( false === $bad_repo['success'], 'unregistered repo must be rejected' );
@@ -300,6 +314,55 @@ roadie_test_assert(
 	false !== strpos( $call['input']['body'], 'extrachill.test' ),
 	'file_issue body attribution includes subsite URL'
 );
+
+// --- file_issue: repo auto-inferred from subsite context ---------------
+// Simulate a team member chatting from events.extrachill.com (blog 7) with
+// extrachill-events active. Omitting repo should infer Extra-Chill/extrachill-events
+// from the active subsite plugin via the slug-to-repo registry.
+$GLOBALS['extrachill_roadie_test_state']['current_blog']   = 7;
+$GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array( 'extrachill-events/extrachill-events.php' );
+$GLOBALS['extrachill_roadie_test_state']['ability_calls']  = array();
+
+$inferred = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'title'  => 'Calendar load-more frozen on June 9',
+	'body'   => 'The events calendar load-more button stops responding at June 9.',
+) );
+roadie_test_assert( true === $inferred['success'], 'file_issue succeeds with repo inferred from subsite context' );
+roadie_test_assert(
+	'Extra-Chill/extrachill-events' === ( $inferred['data']['repo'] ?? '' ),
+	'repo auto-infers to Extra-Chill/extrachill-events from the active subsite plugin'
+);
+roadie_test_assert(
+	true === ( $inferred['data']['repo_inferred'] ?? false ),
+	'success payload flags repo_inferred so the model confirms once instead of asking repeatedly'
+);
+$inferred_call = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert(
+	'Extra-Chill/extrachill-events' === ( $inferred_call['input']['repo'] ?? '' ),
+	'inferred repo is forwarded to the create-github-issue ability'
+);
+
+// Explicit repo still wins over inference, and is flagged as not inferred.
+$GLOBALS['extrachill_roadie_test_state']['ability_calls'] = array();
+$explicit = $tool->handle_tool_call( array(
+	'action' => 'file_issue',
+	'repo'   => 'Extra-Chill/extrachill-roadie',
+	'title'  => 'Explicit repo wins',
+	'body'   => 'Caller named the repo directly.',
+) );
+roadie_test_assert(
+	'Extra-Chill/extrachill-roadie' === ( $explicit['data']['repo'] ?? '' ),
+	'explicit repo param overrides subsite inference'
+);
+roadie_test_assert(
+	false === ( $explicit['data']['repo_inferred'] ?? true ),
+	'explicit repo is not flagged as inferred'
+);
+
+// Restore the default blog/plugins for any later assertions.
+$GLOBALS['extrachill_roadie_test_state']['current_blog']   = 1;
+$GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array();
 
 // --- list_recent_issues: PR filtering, normalization, defaults ---------
 


### PR DESCRIPTION
## Summary

Fixes the two independent failures from #38 where a team member asking Roadie to *"open an issue on github"* from a subsite (1) got the **wrong tool** (`create_taxonomy_term` made a stray "Bug" category) and (2) got **looped 5×** asking "which repo?" even though `blog_id`/`site_host` + the repo-map already had everything needed.

Closes #38.

## Fix 1 — server-side repo inference in `file_feature_request`

- `repo` is now **optional** (removed from the hard-`required` list).
- When omitted/empty, the tool infers it server-side via a new `infer_repo_from_context()`:
  - Resolves the current blog with `get_current_blog_id()`.
  - Uses `extrachill_roadie_detect_subsite_context()` to get the subsite-specific active plugin/theme slugs.
  - Maps the most subsite-specific slug → `owner/name` via a new thin `extrachill_roadie_repo_for_slug()` lookup in `repo-map.php` (no registry duplication).
  - Priority: subsite-specific active **plugin** slug → active **theme** slug.
- The resolved repo is surfaced back in the success payload via a new **`repo_inferred`** flag so the model confirms **once** instead of interrogating the user.
- **Security unchanged:** inference failure falls through to the existing repo-required error; the registry allowlist and cross-org rejection in `validate_repo()` still apply. Explicit `repo` still wins over inference.
- `home_url()` body-attribution line left as-is.

## Fix 2 — broaden + sharpen the team-tier guidance

`inc/agent-mode/register.php` → `extrachill_roadie_guidance_tools_team()`:

- Broadened the `file_feature_request` line to explicitly cover **bug reports** and the phrasings *"open an issue on github" / "file an issue" / "report a bug"* (not just feature requests).
- Added a **negative steer**: issue/github/bug → `file_feature_request`, **never** `create_taxonomy_term`.
- Noted that `repo` is auto-inferred from the current subsite, so the model should not interrogate the user for the repo.

The tool definition `description` got the same broadening + auto-infer note.

## Tests

`tests/feature-request-tool.php` updated and passing:

- `repo` is now asserted **optional** in the definition.
- New: repo auto-infers to `Extra-Chill/extrachill-events` from the active subsite plugin on blog 7, and forwards to the ability.
- New: `repo_inferred` flag is set on inference, unset on explicit repo.
- New: explicit `repo` overrides inference.
- Reworked the "missing repo" case to prove failed inference (unknown blog, unregistered theme, no subsite plugins) still falls back to the repo-required error.

```
$ php tests/feature-request-tool.php
feature-request tool smoke passed.
```

`php -l` clean on all four touched files. All `contribute-code-*` smoke tests pass.

> **Note on `homeboy test`:** the Playground-backed harness crashes at boot (`PlaygroundCommandCrashError`, before producing structured results) — a pre-existing environment issue unrelated to this change. Two other smoke scripts (`agent-mode-registration-smoke.php`, `frontend-chat-branding-smoke.php`) fail identically on the **clean base** (verified via `git stash`) because they depend on plugin-bootstrap constants they don't stub standalone; not introduced here.

## Files

- `inc/tools/class-file-feature-request.php` — optional repo, `infer_repo_from_context()`, `repo_inferred` in payloads, broadened description.
- `inc/contribute-code/repo-map.php` — new `extrachill_roadie_repo_for_slug()` lookup helper.
- `inc/agent-mode/register.php` — broadened + negative-steered team guidance.
- `tests/feature-request-tool.php` — inference + optional-repo coverage.