### PR TITLE
docs: refresh README + plugin description for current 8-tool, role-aware surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,44 @@
 # Extra Chill Roadie
 
-Extra Chill platform chat tools for [Data Machine](https://github.com/Extra-Chill/data-machine) agents. Roadie gives AI agents the ability to manage artist profiles, link pages, user profiles, and community forums on the Extra Chill network — all through natural language chat.
+Extra Chill platform integration for [Frontend Agent Chat](https://github.com/Extra-Chill/frontend-agent-chat), powered by [Data Machine](https://github.com/Extra-Chill/data-machine) agents. Roadie gives the Extra Chill chat agent the ability to manage artist profiles, link pages, user profiles, and community forums — and, for team members, to file GitHub issues and ship sandboxed code changes — all through natural language chat.
 
 ## What It Does
 
-Roadie is the bridge between Extra Chill's platform features and Data Machine's chat system. It registers four chat tools via the `datamachine_tools` filter, each wrapping cross-site REST calls to the appropriate subsite in the multisite network:
+Roadie is the bridge between Extra Chill's platform features and Data Machine's chat system. It registers **eight chat tools** via the `datamachine_tools` filter and composes a role-aware operating context (the `roadie` agent mode) into the AI prompt. The tool surface a caller actually sees depends on their **tier** (public / team / admin).
 
-| Tool | Site | Description |
-|------|------|-------------|
-| `manage_artist_profile` | artist.extrachill.com | Create, list, get, and update artist profiles |
-| `manage_link_page` | artist.extrachill.com | Full link-in-bio page management (links, socials, styles, settings) |
-| `manage_user_profile` | extrachill.com | View and update community profile (bio, title, city, links) |
-| `manage_community` | community.extrachill.com | Browse forums, create topics, post replies, manage notifications |
+| Tool | Surface | Tier | Description |
+|------|---------|------|-------------|
+| `manage_artist_profile` | artist.extrachill.com | team+ | Create, list, get, and update artist profiles |
+| `manage_link_page` | artist.extrachill.com | team+ | Full link-in-bio page management (links, socials, styles, settings) |
+| `manage_user_profile` | extrachill.com (network) | team+ | View and update the community profile (bio, title, city, links) |
+| `manage_community` | community.extrachill.com | team+ | Browse forums, create topics, post replies, manage notifications |
+| `propose_code_change` | sandbox | team+ | Dispatch a sandboxed coding agent that produces a reviewable patch + preview |
+| `apply_code_change` | host | team+ | Apply an approved sandbox artifact: commit, push, open a PR |
+| `file_feature_request` | GitHub | team+ | File / look up GitHub issues against the right EC repo (repo auto-inferred) |
+| `present_question` | chat UI | public | Render a multiple-choice question as clickable buttons |
 
-All tools require authentication (`access_level: authenticated`). Artist-scoped tools auto-resolve the artist ID when the user has a single artist profile.
+The four cross-site management tools require authentication (`access_level: authenticated`) and auto-resolve the artist ID when the user has a single artist profile. The code-contribution and feature-request tools additionally require the `extrachill_propose_code` capability. `present_question` is the only `public`-access tool and is the only tool visible to public-tier callers.
+
+## Role-Aware Tier Surface
+
+Roadie resolves every caller to one of three tiers and tailors both the **visible tool set** and the **prompt guidance** accordingly.
+
+| Tier | Who | Tool surface |
+|------|-----|--------------|
+| `public` | Logged-out / non-team callers, and system/pipeline runs (`calling_user_id <= 0`) | `present_question` only |
+| `team` | `extra_chill_team` members (have the `access_roadie` cap) | All 8 tools |
+| `admin` | `manage_options` users | All 8 tools, plus act-on-behalf-of another user via explicit `user_id` |
+
+Tier resolution lives in `extrachill_roadie_user_tier( int $user_id )` (`inc/permissions.php`) — a single auditable capability→tier map (highest wins): `manage_options` → admin, `access_roadie` → team, otherwise public.
+
+Two enforcement layers back this:
+
+1. **Tool visibility** — `extrachill_roadie_filter_tools_by_tier()` hooks `datamachine_resolved_tools` and, for public-tier callers, `unset()`s the seven management tools returned by `extrachill_roadie_managed_tool_slugs()` (everything except `present_question`). This avoids offering the model dead options.
+2. **Per-call gates** — independent of visibility: cross-site write capability checks, `assert_acting_user_allowed()` (admin-only act-on-behalf-of), and `current_user_can( 'extrachill_propose_code' )` on the code/issue tools.
 
 ## Architecture
 
-Roadie follows the Extra Chill platform pattern: **business logic lives in domain plugins** (extrachill-users, extrachill-api, etc.), and Roadie provides the AI-facing tool interface on top.
+Roadie follows the Extra Chill platform pattern: **business logic lives in domain plugins** (extrachill-users, extrachill-api, extrachill-artist-platform, etc.), and Roadie provides the AI-facing tool interface on top.
 
 ```
 User (chat) → Data Machine → Roadie Tool → ec_cross_site_rest_request() → Subsite REST API → Ability
@@ -25,7 +46,7 @@ User (chat) → Data Machine → Roadie Tool → ec_cross_site_rest_request() �
 
 ### ECRoadie_PlatformTool
 
-All tools extend `ECRoadie_PlatformTool`, which extends Data Machine's `BaseTool` and provides:
+The four cross-site management tools extend `ECRoadie_PlatformTool` (`inc/tools/class-ec-platform-tool.php`), which extends Data Machine's `BaseTool` and provides:
 
 - **`rest_request( $method, $path, $args )`** — Cross-site REST calls via `ec_cross_site_rest_request()`. Pass `user_id` in `$args` to authenticate the request as that user; the underlying helper wraps `wp_set_current_user()` in a try/finally so context restores cleanly.
 - **`get_blog_id()`** — Site key resolution for safe data reads via `switch_to_blog()`.
@@ -33,11 +54,11 @@ All tools extend `ECRoadie_PlatformTool`, which extends Data Machine's `BaseTool
 - **`resolve_acting_user_id( $parameters )`** — Returns the user the tool should act as. Priority: explicit `user_id` input → `calling_user_id` → `get_current_user_id()`.
 - **`assert_acting_user_allowed( $acting, $parameters )`** — Returns a clean permission-denied response (or `null` when allowed). Non-admin callers attempting to act on another user are refused.
 
-Each tool declares a `$site_key` (e.g. `'artist'`, `'community'`, `'main'`) and a `$tool_slug` for error context.
+Each tool declares a `$site_key` (e.g. `'artist'`, `'community'`, `'main'`) and a `$tool_slug` for error context. The code-contribution, feature-request, and present-question tools extend `BaseTool` directly (they don't make cross-site REST calls).
 
 ### Agent Mode
 
-Roadie registers a `roadie` execution mode with Data Machine's `AgentModeRegistry`. The mode is the operating context for the EC platform tool surface — it composes EC-specific guidance (network topology, tool selection, identity contract, editorial voice, operating posture) into the AI prompt at directive priority 22.
+Roadie registers a `roadie` execution mode with Data Machine's `AgentModeRegistry`. The mode is the operating context for the EC platform tool surface — it composes EC-specific guidance (network topology, tool selection, identity contract, editorial voice, operating posture) into the AI prompt.
 
 ```php
 // inc/agent-mode/register.php
@@ -52,6 +73,8 @@ add_filter( 'datamachine_agent_mode_roadie', 'extrachill_roadie_mode_guidance', 
 ```
 
 The mode is **agent-agnostic** — any agent (extra-chill-bot, roadie, or a custom one) can run in this mode and inherit the same platform guidance. Priority `45` places it after `data-machine-editor` (`40`) so editor mode wins when both are active in the same invocation (rare).
+
+The guidance is **role-aware**: `extrachill_roadie_mode_guidance()` resolves the caller's `calling_user_id` → tier and delegates to `extrachill_roadie_compose_guidance( $tier, $uid )`, which assembles tier-specific sections (intro, tool guidance, identity contract, operating posture) on top of shared sections (network topology, editorial voice). The composed prompt is titled `# Extra Chill Platform Context`.
 
 ### Calling-User Identity Contract
 
@@ -73,36 +96,26 @@ The contract for tool wiring:
 
 Admin agents may target another user by passing an explicit `user_id` input; non-admins attempting that get a clean permission-denied response.
 
-### Adding a New Roadie Tool
-
-The pattern that lands a new EC platform tool:
-
-1. Create `inc/tools/class-<name>.php` extending `ECRoadie_PlatformTool`.
-2. Declare `$site_key` (which subsite the route belongs to) and `$tool_slug`.
-3. In the constructor, call `$this->registerTool( '<slug>', [ $this, 'getToolDefinition' ], [ 'chat' ], [ 'access_level' => 'authenticated' ] )`.
-4. Implement `getToolDefinition()` — include an optional `user_id` input parameter in the schema so admins can override.
-5. Implement `handle_tool_call( array $parameters, array $tool_def = array() )` — start with the resolve + assert pair above.
-6. Use `$this->rest_request()` for every cross-site call. Pass `user_id` in `$args`.
-7. Add the `require_once` + `new ECRoadie_<Name>()` lines to `inc/tools/register.php`.
-
-Mode-specific guidance for the new tool can be folded into the existing `extrachill_roadie_mode_guidance()` callback — there is no need for a separate mode unless the tool lives in a different operating context.
-
 ### Permissions
 
 Roadie bridges Extra Chill team membership to Data Machine's agent access system:
 
-- Hooks `datamachine_can_access_agent` to grant EC team members access to the Roadie agent
-- Uses `ec_is_team_member()` as the source of truth
-- Agent policy (name, status, redirect URIs) is synced on `plugins_loaded`
+- Hooks `datamachine_can_access_agent` to grant EC team members access to the Roadie agent.
+- Uses the network-wide `access_roadie` capability (granted to the `extra_chill_team` role) as the source of truth.
+- Grants `extrachill_propose_code` to administrators, editors, and `extra_chill_team` by default (filterable via `extrachill_roadie_propose_code_roles`).
+- Bridges the events read/write capabilities (`datamachine_events_read_capability` / `datamachine_events_write_capability`).
+- Agent policy (name, status, redirect URIs) is synced on `plugins_loaded` (priority 20).
 
 ### Bridge Onboarding
 
 For external chat clients (like Beeper/Matrix via [mautrix-data-machine](https://github.com/Extra-Chill/mautrix-data-machine)), Roadie provides onboarding configuration via the `datamachine_bridge_onboarding_config` filter:
 
-- Welcome message, description, login instructions
-- Room name and topic for the chat bridge
-- Capability list (artist profile, link page, user profile, community)
-- Avatar URL (filterable via `extrachill_roadie_bridge_avatar_url`)
+- Welcome message, description, login instructions.
+- Room name and topic for the chat bridge.
+- Consumer-facing capability list (artist profile, link page, user profile, community).
+- Avatar URL (filterable via `extrachill_roadie_bridge_avatar_url`).
+
+The onboarding capability list is intentionally end-user-facing — the team-gated code and issue tools aren't advertised there because a public bridge user would never see them.
 
 ## Chat Tool Reference
 
@@ -115,7 +128,7 @@ For external chat clients (like Beeper/Matrix via [mautrix-data-machine](https:/
 | `create` | Create a new artist profile | `name` |
 | `update` | Update an existing artist profile | `artist_id` (auto-resolved), plus fields to update |
 
-Optional fields for create/update: `bio`, `genre`, `local_city`, `profile_image_id`, `header_image_id`.
+Optional fields for create/update: `bio`, `genre`, `local_city`, `profile_image_id` (0 to remove), `header_image_id` (0 to remove).
 
 ### manage_link_page
 
@@ -126,7 +139,7 @@ Optional fields for create/update: `bio`, `genre`, `local_city`, `profile_image_
 | `remove_link` | Remove a link | `url` or `link_id` |
 | `save_links` | Replace all link sections | `links` array |
 | `save_socials` | Replace social links | `socials` array |
-| `save_styles` | Update CSS variables | `css_vars` object |
+| `save_styles` | Update CSS variables (keys must start `--link-page-`) | `css_vars` object |
 | `save_settings` | Update settings | `settings` object |
 
 Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save cycle internally so the AI doesn't need multi-step orchestration.
@@ -139,26 +152,83 @@ Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save cyc
 | `update` | Update bio, title, or city | At least one of `custom_title`, `bio`, `local_city` |
 | `update_links` | Replace profile links | `links` array |
 
-Profile links support types: `website`, `facebook`, `instagram`, `twitter`, `youtube`, `tiktok`, `spotify`, `soundcloud`, `bandcamp`, `github`, `other`.
+Profile links support types: `website`, `facebook`, `instagram`, `twitter`, `youtube`, `tiktok`, `spotify`, `soundcloud`, `bandcamp`, `github`, `other`. These are the links on the user's community profile — distinct from artist link pages.
 
 ### manage_community
 
 | Action | Description | Required Params |
 |--------|-------------|-----------------|
-| `list_forums` | Browse available forums | — |
-| `list_topics` | List topics (optionally filtered by forum) | Optional `forum_id` |
+| `list_forums` | Browse available forums (public read) | — |
+| `list_topics` | List topics (optionally filtered by forum) | Optional `forum_id`, `page`, `per_page` |
 | `get_topic` | Read a topic with replies | `topic_id` |
 | `create_topic` | Post a new topic | `forum_id`, `title`, `content` |
 | `create_reply` | Reply to a topic | `topic_id`, `content` |
-| `get_notifications` | Check notifications | Optional `unread` filter |
+| `get_notifications` | Check notifications | Optional `unread` |
 | `mark_notifications_read` | Mark all as read | — |
+
+The first three actions are public reads (no user context); the rest resolve and authorize the acting user.
+
+### propose_code_change
+
+Dispatches a sandboxed coding agent ([WP Codebox](https://github.com/chubes4/wp-codebox) Playground) that implements the described change against the subsite's stack and returns a reviewable patch artifact + live preview URL. **It does not push code or open a PR.**
+
+| Param | Description |
+|-------|-------------|
+| `task_description` (required) | Plain-language description of the change |
+
+Returns `status: pending-approval`, `artifact_id`, `preview_url`, `summary`, `changed_files`. Requires the `extrachill_propose_code` capability. See [docs/contribute-code.md](docs/contribute-code.md) for the full flow.
+
+### apply_code_change
+
+Applies a previously-approved artifact: creates a worktree per affected repo, applies the patch, commits with a conventional commit message, pushes, and opens a pull request.
+
+| Param | Description |
+|-------|-------------|
+| `artifact_id` (required) | The `artifact_id` returned by `propose_code_change` |
+| `commit_message_hint` (optional) | Hint for the commit subject |
+
+Returns `pr_urls`. Only call after the user has explicitly approved the proposed change. Requires `extrachill_propose_code`.
+
+### file_feature_request
+
+Files or looks up GitHub issues against the appropriate Extra Chill repo. **`repo` is optional** — when omitted, it's auto-inferred from the current subsite (active subsite plugin slug, then theme slug) via the slug→repo registry. The response includes a `repo_inferred` flag so the model can confirm an inferred repo once rather than interrogating the user.
+
+| Action | Description | Required Params |
+|--------|-------------|-----------------|
+| `file_issue` | Create a new issue | `title`, `body` (repo optional/inferred) |
+| `list_recent_issues` | Find existing open issues to dedupe against | — (repo optional/inferred) |
+| `comment_on_issue` | Add a comment to an existing issue | `issue_number`, `body` (repo optional/inferred) |
+
+Default labels (`roadie-submitted`, `feature-request`) are applied to filed issues; the repo allowlist and labels are filterable. The repo must be present in the registry; cross-org repos are rejected. Requires `extrachill_propose_code`.
+
+### present_question
+
+Renders a multiple-choice question as clickable buttons in the chat UI. Use when the answer is one of a small, well-defined set of options. Clicking a choice sends its `message` back as the user's next turn automatically.
+
+| Param | Description |
+|-------|-------------|
+| `question` (required) | The question text |
+| `choices` (required) | Array of `{ label, message, description? }` objects |
+| `allow_freeform` (optional) | Signal the UI may also offer a free-text answer |
+
+No capability gate, no side effects — `access_level: public`. This is the only tool offered to public-tier callers.
+
+## Sandbox-Backed Code Contribution
+
+`propose_code_change` + `apply_code_change` implement a human-gated, sandbox-backed code-contribution flow: team members describe a change in chat, a Playground sandbox implements it and returns a patch + preview, and on explicit approval Roadie applies the patch to a fresh worktree on the host, commits, pushes, and opens a PR. The sandbox never touches GitHub, never holds the GitHub token, and never reaches production.
+
+The slug→repo registry (`inc/contribute-code/repo-map.php`, filter `extrachill_roadie_repo_map`) maps active components on a subsite to GitHub repos and is shared by both the code-contribution recipe builder and `file_feature_request`'s repo inference.
+
+Full setup, security model, architecture diagram, and smoke test: **[docs/contribute-code.md](docs/contribute-code.md)**.
 
 ## Dependencies
 
-- **[Data Machine](https://github.com/Extra-Chill/data-machine)** — Provides `BaseTool` class and the `datamachine_tools` filter
-- **[Extra Chill Multisite](https://github.com/Extra-Chill/extrachill-multisite)** — Provides `ec_cross_site_rest_request()` for internal cross-site HTTP
-- **[Extra Chill API](https://github.com/Extra-Chill/extrachill-api)** — REST endpoints and route affinity middleware
-- **[Extra Chill Users](https://github.com/Extra-Chill/extrachill-users)** — User profile abilities and `ec_is_team_member()`
+- **[Data Machine](https://github.com/Extra-Chill/data-machine)** — Provides `BaseTool`, the `datamachine_tools` filter, the `AgentModeRegistry`, and the GitHub-issue abilities.
+- **[Frontend Agent Chat](https://github.com/Extra-Chill/frontend-agent-chat)** — The chat widget Roadie surfaces in; Roadie bridges its config + theme tokens.
+- **[Extra Chill Multisite](https://github.com/Extra-Chill/extrachill-multisite)** — Provides `ec_cross_site_rest_request()` for internal cross-site HTTP.
+- **[Extra Chill API](https://github.com/Extra-Chill/extrachill-api)** — REST endpoints and route affinity middleware.
+- **[Extra Chill Users](https://github.com/Extra-Chill/extrachill-users)** — User profile abilities, team membership, and the `access_roadie` capability.
+- **[WP Codebox](https://github.com/chubes4/wp-codebox)** — Playground sandboxes for `propose_code_change` (code contribution only).
 
 ## Requirements
 
@@ -169,35 +239,78 @@ Profile links support types: `website`, `facebook`, `instagram`, `twitter`, `you
 
 ## Filters
 
+### Hooks Roadie provides
+
 | Filter | Description |
 |--------|-------------|
-| `datamachine_tools` | Registers all four chat tools (via BaseTool) |
-| `datamachine_agent_modes` | Registers the `roadie` execution mode with AgentModeRegistry |
-| `datamachine_agent_mode_roadie` | Provides the roadie mode guidance string (network topology, tool selection, identity contract, editorial voice, operating posture) |
-| `datamachine_can_access_agent` | Bridges EC team membership to Roadie agent access |
-| `datamachine_bridge_onboarding_config` | Provides Roadie-specific onboarding for bridge clients |
+| `extrachill_roadie_repo_map` | Slug→repo registry (shared by code contribution + feature requests) |
 | `extrachill_roadie_allowed_redirect_uris` | External redirect URIs allowed for bridge auth |
 | `extrachill_roadie_bridge_avatar_url` | Override the Roadie avatar URL |
+| `extrachill_roadie_propose_code_roles` | Roles granted `extrachill_propose_code` (default: administrator, editor, extra_chill_team) |
+| `extrachill_roadie_subsite_context` | Detected subsite context (active theme + plugins) |
+| `extrachill_roadie_excluded_plugin_slugs` | Platform plugins excluded from subsite detection |
+| `extrachill_roadie_workspace_root` | DMC workspace root path (default `/var/lib/datamachine/workspace`) |
+| `extrachill_roadie_recipe` | Built sandbox recipe |
+| `extrachill_roadie_inherit_connectors` | Connector→metadata map for sandbox credential inheritance |
+| `extrachill_roadie_preview_hold_seconds` | Sandbox preview TTL (default 900, max 3600) |
+| `extrachill_roadie_inherit_connector_names` | Connector names passed to the sandbox (default `['openai']`) |
+| `extrachill_roadie_propose_code_input` | Input to the `wp-codebox/run-agent-task` ability |
+| `extrachill_roadie_artifacts_root` | wp-codebox artifacts root path |
+| `extrachill_roadie_apply_commit_name` / `extrachill_roadie_apply_commit_email` | Commit author identity for apply-back |
+| `extrachill_roadie_feature_request_allowed_repos` | Repo allowlist for `file_feature_request` |
+| `extrachill_roadie_feature_request_default_labels` | Default labels for filed issues |
+| `extrachill_roadie_feature_request_attribution_lines` | Issue/comment attribution footer |
+| `extrachill_roadie_file_issue_input` / `_list_issues_input` / `_comment_issue_input` | Inputs to the GitHub-issue abilities |
+
+### Hooks Roadie consumes
+
+| Hook | Purpose |
+|------|---------|
+| `datamachine_tools` | Registers all eight chat tools (via BaseTool) |
+| `datamachine_resolved_tools` | Filters the tool surface by caller tier |
+| `datamachine_agent_modes` | Registers the `roadie` execution mode with AgentModeRegistry |
+| `datamachine_agent_mode_roadie` | Provides the role-aware roadie mode guidance |
+| `datamachine_can_access_agent` | Bridges EC team membership to Roadie agent access |
+| `datamachine_events_read_capability` / `datamachine_events_write_capability` | Bridges events read/write caps |
+| `datamachine_bridge_onboarding_config` | Provides Roadie-specific onboarding for bridge clients |
+| `wp_codebox_resolve_inheritance` | Resolves sandbox credential inheritance (e.g. OpenAI key) |
+| `frontend_agent_chat_config` / `frontend_agent_chat_chat_input` / `frontend_agent_chat_queue_input` | Bridges chat config + page context |
+| `user_has_cap` | Grants `extrachill_propose_code` to configured roles |
 
 ## File Structure
 
 ```
-extrachill-roadie.php          # Plugin bootstrap
+extrachill-roadie.php              # Plugin bootstrap
 inc/
-  permissions.php              # Team access bridge + agent policy sync
-  onboarding.php               # Bridge onboarding config (Beeper/Matrix)
+  permissions.php                  # Tier resolution + team access bridge + agent policy sync
+  frontend-chat.php                # Frontend Agent Chat config + page-context bridge
+  onboarding.php                   # Bridge onboarding config (Beeper/Matrix)
+  assets.php                       # Token-bridge CSS enqueue
   agent-mode/
-    register.php               # AgentModeRegistry registration + roadie mode guidance
+    register.php                   # AgentModeRegistry registration + role-aware guidance
   tools/
-    register.php               # Tool registration on plugins_loaded
-    class-ec-platform-tool.php # Base class — REST helper, calling-user resolution, permission guard
+    register.php                   # Tool registration + tier visibility filter
+    class-ec-platform-tool.php     # Base for cross-site tools — REST helper, identity, permission guard
     class-manage-artist-profile.php
     class-manage-link-page.php
     class-manage-user-profile.php
     class-manage-community.php
+    class-propose-code-change.php  # Dispatch sandbox coding agent
+    class-apply-code-change.php    # Apply approved artifact → commit/push/PR
+    class-file-feature-request.php # File/look up GitHub issues (repo auto-inferred)
+    class-present-question.php     # Multiple-choice question cards
+  contribute-code/
+    subsite-context.php            # Detect active theme + subsite plugins for a blog
+    repo-map.php                   # Slug→repo registry + lookup helpers
+    recipe-builder.php             # Build the sandbox recipe (mounts, metadata)
+    capabilities.php               # extrachill_propose_code capability grants
+    inherit-resolver.php           # Bridge connector credentials into the sandbox
+assets/
+  css/token-bridge.css             # EC theme tokens → chat widget tokens
 docs/
   CHANGELOG.md
-homeboy.json                   # Homeboy deployment config
+  contribute-code.md               # Sandbox-backed code-contribution flow
+homeboy.json                       # Homeboy deployment config
 ```
 
 ## Deployment

--- a/extrachill-roadie.php
+++ b/extrachill-roadie.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Extra Chill Roadie
  * Plugin URI: https://extrachill.com
- * Description: Extra Chill platform integration for Frontend Agent Chat. Provides artist profiles, link pages, user profiles, and community forum tools via the datamachine_tools filter, plus the EC theme token bridge for the chat widget.
+ * Description: Extra Chill platform integration for Frontend Agent Chat. Registers a role-aware tool surface via the datamachine_tools filter — artist profiles, link pages, user profiles, and community forums, plus team-gated GitHub issue filing and sandbox-backed code contributions — and bridges EC theme tokens into the chat widget.
  * Version: 0.10.0
  * Author: Chris Huber
  * Author URI: https://chubes.net

--- a/inc/onboarding.php
+++ b/inc/onboarding.php
@@ -43,10 +43,11 @@ function extrachill_roadie_bridge_onboarding_config( array $config, string $agen
 	$config['display_name'] = EXTRACHILL_ROADIE_AGENT_NAME;
 
 	$config['description'] = 'Roadie is your personal assistant on Extra Chill. '
-		. 'Manage your artist profile, link page, community posts, and more — all through chat.';
+		. 'Manage your artist profile, link page, and community posts through chat. '
+		. 'Extra Chill team members can also file issues and propose code changes.';
 
 	$config['welcome_message'] = "Hey! I'm Roadie, your assistant on Extra Chill. "
-		. "I can help you manage your artist profile, update your link page, post in the community forums, and more.\n\n"
+		. "I can help you manage your artist profile, update your link page, and post in the community forums.\n\n"
 		. 'What would you like to do?';
 
 	$config['login_label'] = 'Sign in to Extra Chill';
@@ -58,13 +59,22 @@ function extrachill_roadie_bridge_onboarding_config( array $config, string $agen
 	$config['room_name']  = 'Roadie';
 	$config['room_topic'] = 'Extra Chill assistant — manage your profile, link page, and community.';
 
-	// Capabilities the user can use through chat.
+	// Capabilities the user can use through chat. Team-only capabilities
+	// (issue filing, code contribution) are gated server-side and only
+	// surface for extra_chill_team / admin callers, so they're listed
+	// separately rather than advertised to every onboarding user.
 	$config['capabilities'] = array(
 		'artist_profile' => 'Create and manage your artist profile',
 		'link_page'      => 'Update your link-in-bio page',
 		'user_profile'   => 'Edit your community profile',
 		'community'      => 'Browse forums, post topics, and reply',
 	);
+
+	// Team-tier capabilities (only usable by extra_chill_team / admins).
+	if ( function_exists( 'current_user_can' ) && current_user_can( 'extrachill_propose_code' ) ) {
+		$config['capabilities']['feature_request'] = 'File feature requests and bug reports as GitHub issues';
+		$config['capabilities']['code_contribution'] = 'Propose sandboxed code changes and open pull requests';
+	}
 
 	// Avatar: use the Roadie agent's avatar if available via DM, otherwise fall back to site icon.
 	$avatar_url = '';


### PR DESCRIPTION
## Summary

The Roadie docs had drifted well behind the implementation. The README documented **4 tools** when **8** exist, with no mention of the role-aware tier surface, the sandbox-backed code-contribution flow, `file_feature_request`, or `present_question`. The plugin header Description and bridge onboarding were similarly narrow. This PR brings all three in line with `main` (post-#39).

## What changed

**README.md** — full rewrite:
- Documents all **8 tools** (added `propose_code_change`, `apply_code_change`, `file_feature_request`, `present_question`) with per-action param tables.
- New **Role-Aware Tier Surface** section: `public` / `team` / `admin` tiers, `extrachill_roadie_user_tier()`, the `datamachine_resolved_tools` visibility filter, and which tools each tier sees.
- Documents the now **role-aware agent-mode guidance** (still filter `datamachine_agent_mode_roadie`, priority 45) composed from tier-specific sections.
- Documents `file_feature_request` **repo auto-inference** (optional `repo`, `repo_inferred` flag) shipped in #39.
- Corrected **File Structure** (adds the whole `contribute-code/` dir + the 5 new tool files).
- Complete **Filters** tables (~20 `extrachill_roadie_*` provided hooks + the hooks Roadie consumes).
- Points to `docs/contribute-code.md` for the sandbox flow.

**extrachill-roadie.php** — plugin header `Description` updated to mention the role-aware surface, GitHub issue filing, and code contributions.

**inc/onboarding.php** — bridge onboarding description + capabilities now surface the team-gated `feature_request` / `code_contribution` capabilities for callers who hold `extrachill_propose_code` (end-user capability list unchanged for non-team users).

**GitHub repo description** — updated out-of-band via `gh repo edit` to match.

## Notes
- Docs only + one capability-list addition gated behind `current_user_can( 'extrachill_propose_code' )`. No tool behavior changes.
- `php -l` clean on both edited PHP files.
- No version bump / no CHANGELOG edit (homeboy owns those).