### PR TITLE
docs: correct contribute-code.md drift (capabilities, repo-map, upstream status)

### DIFF
--- a/docs/contribute-code.md
+++ b/docs/contribute-code.md
@@ -17,6 +17,10 @@ The sandbox never touches GitHub, never touches production code, and never holds
 
 The structural human gate is: the LLM is told in `propose_code_change`'s description not to auto-call `apply_code_change` — it must wait for the user to approve. Capability check on both tools (`extrachill_propose_code`) is the second gate.
 
+### Implement now vs. track it
+
+`propose_code_change` is for **implementing** a change right now. When the user just wants to **track** something — a feature idea or bug report — the sibling `file_feature_request` tool files a GitHub issue instead (same `extrachill_propose_code` capability, same `repo-map.php` registry for resolving the target repo). The model is steered to pick `file_feature_request` for "open an issue / file an issue / report a bug" phrasing and `propose_code_change` when the user wants the change actually made. `file_feature_request` auto-infers the repo from the current subsite, so a team member chatting on `events.extrachill.com` can file against `Extra-Chill/extrachill-events` without naming it.
+
 ## Setup
 
 ### 1. Host prerequisites
@@ -94,7 +98,7 @@ add_filter( 'extrachill_roadie_inherit_connectors', function ( array $map ) {
 
 ### 5. Capabilities
 
-By default, administrators and editors get `extrachill_propose_code`. Override:
+By default, **administrators, editors, and the `extra_chill_team` role** get `extrachill_propose_code` (granted via the `user_has_cap` filter, so no DB writes on upgrade). `file_feature_request` gates on the same capability — if you can propose code, you can file issues. Override the role grant:
 
 ```php
 add_filter( 'extrachill_roadie_propose_code_roles', function ( array $roles ) {
@@ -102,9 +106,22 @@ add_filter( 'extrachill_roadie_propose_code_roles', function ( array $roles ) {
 } );
 ```
 
+Per-user grants work through the standard `user_has_cap` filter. There is no separate "approve" capability — chat approval happens through the same conversation surface.
+
 ### 6. Slug → repo map
 
-The recipe builder maps active components on the subsite to GitHub repos via the `extrachill_roadie_repo_map` filter. Defaults cover the Extra Chill theme + commonly active plugins. Add new entries:
+The slug→repo registry (`inc/contribute-code/repo-map.php`, filter `extrachill_roadie_repo_map`) is the **single allowlist shared by both** the code-contribution recipe builder and `file_feature_request`'s repo inference. Each entry carries a `kind`:
+
+| `kind` | Meaning | Mounted editable in sandbox? | Issue-trackable? |
+|---|---|---|---|
+| `theme` | `wp-content/themes/<slug>/` | Yes | Yes |
+| `plugin` | Subsite-specific plugin | Yes | Yes |
+| `platform-plugin` | Network-wide platform plugin (boilerplate from a subsite's POV) | No — excluded from subsite detection | Yes |
+| `agent-stack-plugin` | Read-only reference the sandboxed agent can grep | Read-only mount | Reference only |
+
+The default map ships ~26 entries: the `extrachill` theme, the subsite plugins (`extrachill-artist-platform`, `-community`, `-events`, `-shop`, `-blog`, `-contact`, `-content-blocks`, `-docs`, `-ai-adventure`), the network platform plugins (`extrachill-roadie`, `-users`, `-multisite`, `-api`, `-admin-tools`, `-newsletter`, `-search`, `-seo`, `-analytics`, `-cli`, `-tokens`, `-components`), and the agent stack (`agents-api`, `data-machine`, `data-machine-code`, `ai-provider-for-openai`, `ai-provider-for-anthropic` — the two WordPress providers track `trunk`).
+
+Add new entries:
 
 ```php
 add_filter( 'extrachill_roadie_repo_map', function ( array $map ) {
@@ -118,7 +135,11 @@ add_filter( 'extrachill_roadie_repo_map', function ( array $map ) {
 } );
 ```
 
-If a contributor describes a change to a plugin that isn't in the map, the recipe still ships but that plugin won't be mounted as editable. The response includes the unmapped slug in `unmapped_plugins` for operator visibility.
+Helpers over the registry:
+- `extrachill_roadie_repo_for_slug( $slug )` — thin slug → `owner/name` lookup (`''` if unknown). This is what `file_feature_request`'s `infer_repo_from_context()` consumes to auto-resolve the repo from the current subsite's active plugin (then theme) slug.
+- `extrachill_roadie_agent_stack_slugs()` — the read-only `agent-stack-plugin` slugs.
+
+If a contributor describes a change to a `plugin`/`theme` slug that isn't in the map, the recipe still ships but that plugin won't be mounted as editable. The response includes the unmapped slug in `unmapped_plugins` for operator visibility. `platform-plugin` and `agent-stack-plugin` entries are deliberately not auto-mounted editable on a subsite, but remain in the registry for issue-tracking and explicit-target flows.
 
 ## Architecture
 
@@ -210,7 +231,7 @@ echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
 ## Operational notes
 
 - **Preview URL TTL:** controlled by `preview_hold_seconds` (default 900). Override via `extrachill_roadie_preview_hold_seconds` filter. Max 3600.
-- **Worktree convention:** apply-back creates worktrees as `<repo>@roadie-<slug>-<short-artifact-id>`. These are tracked in the DMC workspace registry and can be cleaned up via `wp datamachine-code workspace worktree mark-cleanup-eligible <handle>` after PR merge.
+- **Worktree convention:** apply-back pushes a `roadie/<slug>-<short12>` branch (12-char artifact-id prefix) and creates the worktree as `<repo>@roadie-<slug>-<short12>` (the DMC on-disk handle replaces `/` with `-`). These are tracked in the DMC workspace registry and can be cleaned up via `wp datamachine-code workspace worktree mark-cleanup-eligible <handle>` after PR merge.
 - **Commit identity:** all commits authored by `Extra Chill Bot <bot@extrachill.com>` (configured via `extrachill_roadie_apply_commit_name` / `extrachill_roadie_apply_commit_email` filters). The PR author on GitHub is whoever owns the resolved credential profile — when using the default `homeboy-ci` App profile, PRs are authored by `homeboy-ci[bot]`.
 - **No release / no deploy:** apply-back opens a PR; merge and release stay manual on GitHub. There is no path from chat to production deploy.
 
@@ -218,8 +239,7 @@ echo wp_json_encode( $result, JSON_PRETTY_PRINT );'
 
 | Issue | Status | What it gives us |
 |---|---|---|
-| [chubes4/wp-codebox#88](https://github.com/chubes4/wp-codebox/issues/88) | Partial (closed via #89) | Declarative inheritance contract for connectors/settings. The `inherit` block + `wp_codebox_resolve_inheritance` filter are live. |
-| [chubes4/wp-codebox#89](https://github.com/chubes4/wp-codebox/pull/89) | Merged | Transport foundation for #88. Provider/model/secret_env-names crossover via the filter. |
-| Remaining #88 scope | Open | Agent identity inheritance (custom SOUL/MEMORY for the sandbox agent) + filter-returned secret values (eliminating the putenv() bridge). |
+| [chubes4/wp-codebox#88](https://github.com/chubes4/wp-codebox/issues/88) | Closed | Declarative inheritance contract for connectors/settings. The `inherit` block + `wp_codebox_resolve_inheritance` filter are live. |
+| [chubes4/wp-codebox#89](https://github.com/chubes4/wp-codebox/pull/89) | Merged | Transport foundation for #88 — provider/model/secret_env-names crossover via the filter. |
 
-When the remaining #88 scope lands, the `inherit-resolver.php` bridge becomes obsolete: the filter will return values directly instead of `putenv()`ing them, and we can also pass an `inherit.agents` block to give the sandboxed agent a tailored persona.
+**Current bridge (still in place):** `inc/contribute-code/inherit-resolver.php` resolves the connector credential (default OpenAI, `gpt-5`) from the parent site's `connectors_*` option and `putenv()`s it as the `secret_env` var name (e.g. `OPENAI_API_KEY`) so the sandbox's `php-ai-client` picks it up via `getenv()`. Even though #88 is closed upstream, the `putenv()` bridge here has **not** yet been removed — if/when the inheritance contract grows to return secret values directly (and to accept an `inherit.agents` block for a tailored sandbox persona), this bridge becomes obsolete and should be deleted. Track that cleanup as roadie-side tech debt rather than assuming it already happened.


### PR DESCRIPTION
## Summary

Second docs pass after the README refresh (#40), targeting `docs/contribute-code.md`. Audited the sandbox-flow doc against current `main` code and fixed real drift.

## What was stale → fixed

- **Capabilities** — doc said "administrators and editors get `extrachill_propose_code`"; the code now also grants **`extra_chill_team`** by default, and `file_feature_request` gates on the same cap. Corrected + noted the no-separate-approve-cap rationale.
- **Slug → repo map** — doc framed it as code-contribution-only with a vague "theme + commonly active plugins" default. Now documents:
  - the `kind` taxonomy (`theme` / `plugin` / `platform-plugin` / `agent-stack-plugin`) and what each means for mounting vs issue-tracking,
  - the full ~26-entry default set,
  - `extrachill_roadie_repo_for_slug()` + `extrachill_roadie_agent_stack_slugs()` helpers,
  - that the registry is now **shared with `file_feature_request`'s repo inference**.
- **Implement now vs. track it** — new note distinguishing `propose_code_change` (make the change) from the sibling `file_feature_request` (file a GitHub issue), both sharing the cap + repo-map.
- **Upstream work** — `chubes4/wp-codebox#88` is now **CLOSED** (doc said "partial/open"). But the `inherit-resolver.php` `putenv()` bridge is **still in place** — reframed from "becomes obsolete when #88 lands" to "still-present roadie-side tech debt to delete," since #88 landed but the bridge wasn't removed.
- **Worktree convention** — spelled out the `roadie/<slug>-<short12>` branch + the DMC `<repo>@roadie-<slug>-<short12>` handle derivation.

## Notes
- Docs only. No code changes. Verified every claim against the current source (`capabilities.php`, `repo-map.php`, `inherit-resolver.php`, `class-apply-code-change.php`, `class-propose-code-change.php`) and the live upstream issue/PR state.
- No version bump / no CHANGELOG edit.