### PR TITLE
fix: use propose-code cap constant in onboarding gate (unblock release lint)

### DIFF
--- a/inc/onboarding.php
+++ b/inc/onboarding.php
@@ -70,9 +70,12 @@ function extrachill_roadie_bridge_onboarding_config( array $config, string $agen
 		'community'      => 'Browse forums, post topics, and reply',
 	);
 
-	// Team-tier capabilities (only usable by extra_chill_team / admins).
-	if ( function_exists( 'current_user_can' ) && current_user_can( 'extrachill_propose_code' ) ) {
-		$config['capabilities']['feature_request'] = 'File feature requests and bug reports as GitHub issues';
+	// Team-tier capabilities (only usable by extra_chill_team / admins). The
+	// capability is registered in inc/contribute-code/capabilities.php; use the
+	// constant when available so the check stays in sync with that definition.
+	$propose_code_cap = defined( 'EXTRACHILL_ROADIE_PROPOSE_CODE_CAP' ) ? EXTRACHILL_ROADIE_PROPOSE_CODE_CAP : 'extrachill_propose_code';
+	if ( function_exists( 'current_user_can' ) && current_user_can( $propose_code_cap ) ) {
+		$config['capabilities']['feature_request']   = 'File feature requests and bug reports as GitHub issues';
 		$config['capabilities']['code_contribution'] = 'Propose sandboxed code changes and open pull requests';
 	}
 


### PR DESCRIPTION
## Summary

The team-tier onboarding capability check added in #40 called `current_user_can( 'extrachill_propose_code' )` with a string literal, which tripped two PHPCS warnings (unknown-capability + equals-alignment) and blocked `homeboy release` preflight lint.

- Use the `EXTRACHILL_ROADIE_PROPOSE_CODE_CAP` constant (registered in `inc/contribute-code/capabilities.php`) when defined, falling back to the literal.
- Align the two `$config['capabilities'][...]` assignments.

No behavior change. `php -l` + `homeboy lint` (PHPCS + PHPStan) pass clean.