### PR TITLE
feat: register agent-stack components for the wp-codebox browser runtime

### DIFF
--- a/inc/contribute-code/recipe-builder.php
+++ b/inc/contribute-code/recipe-builder.php
@@ -213,3 +213,71 @@ function extrachill_roadie_build_recipe( array $context, array $repo_map, array 
 	 */
 	return (array) apply_filters( 'extrachill_roadie_recipe', $recipe, $context, $repo_map, $args );
 }
+
+/*
+|--------------------------------------------------------------------------
+| WP Codebox browser-runtime agent stack registration
+|--------------------------------------------------------------------------
+| WP Codebox is a generic substrate — it does not (and must not) know which
+| downstream plugins make up an agent runtime, nor where to fetch them. The
+| integration layer owns those names. Roadie already bridges the Extra Chill
+| platform into wp-codebox (recipe builder, inheritance resolver), so it is the
+| correct place to declare the browser runtime's required components and their
+| release sources.
+|
+| These mirror the on-disk agent stack roadie mounts via
+| `wp_codebox_component_paths`; the registry below provides the release-zip
+| fallback wp-codebox uses when a component is not already present on disk.
+| Per chubes4/wp-codebox layer-purity issue #633.
+*/
+
+/**
+ * Declare which components the wp-codebox browser runtime must always install.
+ *
+ * @param array<int,string> $slugs Required component slugs.
+ * @return array<int,string>
+ */
+function extrachill_roadie_browser_runtime_required_components( array $slugs ): array {
+	foreach ( array( 'agents-api', 'data-machine', 'data-machine-code' ) as $required ) {
+		if ( ! in_array( $required, $slugs, true ) ) {
+			$slugs[] = $required;
+		}
+	}
+
+	return $slugs;
+}
+add_filter( 'wp_codebox_browser_runtime_required_components', 'extrachill_roadie_browser_runtime_required_components' );
+
+/**
+ * Provide release-zip sources for the agent-stack browser runtime components.
+ *
+ * Used by wp-codebox as the fallback install source when a required component
+ * is not already mounted from an on-disk path.
+ *
+ * @param array<string,array<string,mixed>> $registry Component registry.
+ * @return array<string,array<string,mixed>>
+ */
+function extrachill_roadie_browser_runtime_component_registry( array $registry ): array {
+	$defaults = array(
+		'agents-api'        => 'https://github.com/Automattic/agents-api/releases/latest/download/agents-api.zip',
+		'data-machine'      => 'https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip',
+		'data-machine-code' => 'https://github.com/Extra-Chill/data-machine-code/releases/latest/download/data-machine-code.zip',
+	);
+
+	foreach ( $defaults as $slug => $url ) {
+		if ( isset( $registry[ $slug ] ) ) {
+			continue;
+		}
+
+		$registry[ $slug ] = array(
+			'resource'         => 'url',
+			'url'              => $url,
+			'targetFolderName' => $slug,
+			'activate'         => true,
+			'provenance'       => array( 'source' => 'extrachill-roadie-runtime-component-registry' ),
+		);
+	}
+
+	return $registry;
+}
+add_filter( 'wp_codebox_browser_runtime_component_registry', 'extrachill_roadie_browser_runtime_component_registry' );


### PR DESCRIPTION
## Summary

Companion to **Automattic/wp-codebox#636**, which removes the browser runtime's hardcoded component defaults so the generic sandbox substrate stops naming the plugins that consume it.

With those defaults gone, the integration layer must declare which components the agent runtime needs and where to fetch them. **Roadie is that layer** — it already bridges the Extra Chill platform into wp-codebox (its recipe builder mounts the agent stack, its inheritance resolver hooks `wp_codebox_resolve_inheritance`) and legitimately knows both sides.

## What it does

Registers `agents-api` / `data-machine` / `data-machine-code` via the two new wp-codebox filters, in `inc/contribute-code/recipe-builder.php`:

- `wp_codebox_browser_runtime_required_components` — declares the always-installed agent-stack slugs.
- `wp_codebox_browser_runtime_component_registry` — provides the release-zip sources wp-codebox falls back to when a component is not already mounted from an on-disk `wp_codebox_component_paths` entry.

These mirror exactly what wp-codebox previously shipped hardcoded — same slugs, same URLs — just sourced from the consumer that owns those names.

## Why here

`recipe-builder.php` already documents this responsibility: *"The agent stack (agents-api, data-machine, data-machine-code…) is auto-mounted by WP Codebox… Per chubes4/wp-codebox#82 the recipe builder lives in the consumer (us)."* This change extends that same ownership to the browser-runtime component declarations.

## Tests

`tests/contribute-code-recipe-builder.php` passes (`contribute-code recipe-builder smoke passed`). Registrations are additive and idempotent (skip slugs already present in the registry).

## Sequencing

Merge **after** Automattic/wp-codebox#636 ships and is deployed — until the substrate defaults to empty, this just re-affirms the same components (harmless overlap, since the registrations are idempotent).

Refs Automattic/wp-codebox#633.