### PR TITLE
test: fix host-smoke harness deps so the release preflight runs clean

### DIFF
--- a/tests/agent-mode-registration-smoke.php
+++ b/tests/agent-mode-registration-smoke.php
@@ -52,12 +52,29 @@ function __( $text, $domain = null ): string {
 	return (string) $text;
 }
 
+// extrachill_roadie_user_tier() consults user_can() for non-zero callers. The
+// guidance assertions below exercise the team-tier path (the user-scoped
+// "user #<id>" identity line lives in the team/admin guidance), so grant the
+// test caller the team capability (access_roadie) while withholding admin. This
+// keeps the smoke free of a WordPress bootstrap.
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( $user, $capability, ...$args ): bool {
+		unset( $user, $args );
+		return 'access_roadie' === $capability;
+	}
+}
+
 function ec_roadie_smoke_assert( bool $condition, string $message ): void {
 	if ( ! $condition ) {
 		throw new RuntimeException( $message );
 	}
 }
 
+// permissions.php provides EXTRACHILL_ROADIE_TIER_* constants and
+// extrachill_roadie_user_tier(); register.php references them. With a 0
+// (no-human) caller, the tier resolver short-circuits to the public tier and
+// never touches WP capability functions, so loading it here is side-effect free.
+require_once dirname( __DIR__ ) . '/inc/permissions.php';
 require_once dirname( __DIR__ ) . '/inc/agent-mode/register.php';
 
 // Trigger the action so registration runs.
@@ -85,9 +102,11 @@ ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Calling-User Ident
 ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Editorial Voice' ), 'Guidance should document editorial voice.' );
 ec_roadie_smoke_assert( str_contains( $guidance_with_caller, 'Operating Mode' ), 'Guidance should document operating mode (propose-then-act for writes).' );
 
-// Without a caller, guidance should explain that user-scoped writes have no default.
+// Without a caller (user_id 0), the tier resolver returns the public tier, so
+// guidance uses the visitor identity contract: no user context to act on, tools
+// kept read-only, and a sign-in nudge for anything that would change data.
 $guidance_no_caller = apply_filters( 'datamachine_agent_mode_roadie', '', array() );
-ec_roadie_smoke_assert( str_contains( $guidance_no_caller, 'no human caller' ), 'Guidance should explain the no-caller case for system tasks.' );
+ec_roadie_smoke_assert( str_contains( $guidance_no_caller, 'no user context to act on behalf of' ), 'No-caller guidance should use the visitor identity contract (no user context).' );
 
 // Filter should compose with prior content rather than replace it.
 $composed = apply_filters( 'datamachine_agent_mode_roadie', "# Existing\nPrior directive content.", array() );

--- a/tests/frontend-chat-branding-smoke.php
+++ b/tests/frontend-chat-branding-smoke.php
@@ -32,6 +32,19 @@ function sanitize_title( $value ): string {
 	return trim( (string) $value, '-' );
 }
 
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ): string {
+		unset( $domain );
+		return (string) $text;
+	}
+}
+
+// Toggleable login state for exercising both greeting branches.
+$GLOBALS['extrachill_roadie_test_logged_in'] = false;
+function is_user_logged_in(): bool {
+	return (bool) ( $GLOBALS['extrachill_roadie_test_logged_in'] ?? false );
+}
+
 function roadie_smoke_assert( bool $condition, string $message ): void {
 	if ( ! $condition ) {
 		throw new RuntimeException( $message );
@@ -50,4 +63,14 @@ roadie_smoke_assert( 'Roadie' === ( $default_config['fab_label'] ?? '' ), 'Empty
 $other_config = apply_filters( 'frontend_agent_chat_config', array( 'agent_slug' => 'other-agent' ) );
 roadie_smoke_assert( ! isset( $other_config['fab_label'] ), 'Other explicitly configured agents should keep their launcher branding.' );
 
-echo "Roadie frontend chat branding smoke passed (3 assertions).\n";
+// Role-aware greeting: logged-out visitors get the explore nudge; signed-in
+// callers get the working-assistant framing.
+$GLOBALS['extrachill_roadie_test_logged_in'] = false;
+$logged_out = apply_filters( 'frontend_agent_chat_config', array( 'agent_slug' => 'roadie' ) );
+roadie_smoke_assert( false !== strpos( (string) ( $logged_out['fab_greeting'] ?? '' ), 'sign in' ), 'Logged-out visitors should get the explore-oriented greeting.' );
+
+$GLOBALS['extrachill_roadie_test_logged_in'] = true;
+$logged_in = apply_filters( 'frontend_agent_chat_config', array( 'agent_slug' => 'roadie' ) );
+roadie_smoke_assert( ! empty( $logged_in['fab_greeting'] ) && $logged_in['fab_greeting'] !== ( $logged_out['fab_greeting'] ?? '' ), 'Signed-in callers should get a distinct working-assistant greeting.' );
+
+echo "Roadie frontend chat branding smoke passed (5 assertions).\n";


### PR DESCRIPTION
Closes #46.

## Summary

Two `host-smoke` tests fatal'd with exit 255 because they exercised code paths whose dependencies weren't loaded in the standalone (no-WordPress-bootstrap) host-smoke context. This blocked `homeboy release extrachill-roadie` at `preflight.test`, forcing `--skip-checks` on the v0.11.0 release.

**Production code is unchanged — these were test-harness gaps, not runtime bugs.**

## Fixes

**`agent-mode-registration-smoke.php`**
- Referenced `EXTRACHILL_ROADIE_TIER_PUBLIC` via `register.php` without loading `inc/permissions.php` (where the `EXTRACHILL_ROADIE_TIER_*` constants and `extrachill_roadie_user_tier()` live) → now requires `permissions.php` first.
- Called `user_can()` unstubbed for the non-zero test caller (user 38) → added a stub granting the team capability (`access_roadie`) so the user-scoped guidance path is exercised.
- Corrected the no-caller assertion to match the code's actual routing: `user_id 0` resolves to the **public** tier and uses the visitor identity contract ("no user context to act on behalf of"), not the team "no human caller" wording.

**`frontend-chat-branding-smoke.php`**
- Called `is_user_logged_in()` unstubbed → added a toggleable stub and strengthened the test to assert **both** greeting branches (logged-out explore nudge vs. signed-in working-assistant framing).

## Verification

All four host-smoke suites pass under the homeboy runner:

```
HOST_SMOKE_OK:tests/agent-mode-registration-smoke.php        (14 assertions)
HOST_SMOKE_OK:tests/calling-user-identity-smoke.php          (12 assertions)
HOST_SMOKE_OK:tests/calling-user-permission-denial-smoke.php (28 assertions)
HOST_SMOKE_OK:tests/frontend-chat-branding-smoke.php         (5 assertions)
```

The release preflight that previously required `--skip-checks` now passes clean.