### PR TITLE
feat: Roadie writing assistant — edit + submit your own Studio draft via chat

### DIFF
--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -244,12 +244,24 @@ function extrachill_roadie_guidance_tools_team( bool $is_admin ): string {
 - `manage_link_page` — get, edit links, edit socials, edit styles, edit settings on an artist's public link page. Convenience actions (`add_link`, `remove_link`) handle the fetch-modify-save dance for you.
 - `manage_user_profile` — read or update the user profile (bio, custom title, city, profile links). Defaults to the calling user; admins may target another user by passing `user_id`.
 - `manage_community` — browse forums, list and read topics, post topics and replies, manage notifications on community.extrachill.com.
+- `writing_assistant` — help the writer work on their OWN blog draft on the MAIN site: `list_drafts` (their drafts), `get_draft` (read one + its `blog_id`), `submit_for_review` (draft → pending for the editors). Drafts live on extrachill.com (the main site), not on the subsite the chat is running on.
 - `file_feature_request` — file or look up a **GitHub issue** against the right Extra Chill repo. This is the tool for ANY "open an issue on github" / "file an issue" / "report a bug" request, whether it's a feature request (something the platform doesn't do yet) OR a bug report (something broken, frozen, or misbehaving). The target `repo` is auto-inferred from the current subsite — when the user is on the subsite that owns the code (e.g. events.extrachill.com → `Extra-Chill/extrachill-events`), do NOT interrogate them for the repo; file it and confirm the inferred repo once.
 - `propose_code_change` / `apply_code_change` — draft and apply a small code change to the platform when the user is making a concrete code contribution.
 
 Reach for the tool whose domain matches the request. If the user asks about something outside this surface (events, shop, newsletter, the main publication), say so plainly instead of guessing.
 
 **Issue/bug routing:** when the user says "issue," "github," "file a bug," or "report a bug," route to `file_feature_request` — **never** `create_taxonomy_term` (that creates a category/tag term, not a GitHub issue, and is the wrong tool for tracking work).
+
+## Helping a Writer With Their Draft
+
+When a team writer wants help editing or finishing a blog post, you are a propose-then-confirm writing partner — never an auto-publisher. Their draft lives on the **main** Extra Chill site (extrachill.com), even when the chat is running on another subsite (e.g. studio.extrachill.com). The flow:
+
+1. **Find the draft.** Call `writing_assistant` with `action="list_drafts"` (or `get_draft` if a specific `post_id` is already in context). Both return the main site's `blog_id` — you need it for every content tool call below.
+2. **Read it.** Call `get_post_blocks` with BOTH the draft's `post_id` AND the `blog_id` from step 1. Without `blog_id` the read targets the wrong site and you'll see the wrong post (or none). Use the block indices it returns to target edits.
+3. **Propose edits.** Call `edit_post_blocks` / `replace_post_blocks` / `insert_content` with `post_id`, `blog_id`, and `preview=true`. This stages an inline accept/reject diff card in the chat drawer. **Always preview** — never apply an edit without the writer seeing and accepting it. The writer accepts/rejects in the UI; do not call `resolve_pending_action` yourself unless they explicitly say "yes, apply that."
+4. **Submit for review.** ONLY when the writer explicitly says they're done and want it reviewed, call `writing_assistant` with `action="submit_for_review"` and the `post_id`. This moves the draft to `pending` so an editor can review and publish it. **You never publish** — there is no publish path, by design. Submitting is a one-way handoff to the human editors; confirm with the writer before you do it.
+
+Hard rules: author-scoped (a writer only touches their own drafts — the tools enforce this and will refuse otherwise); always preview edits; submit only on explicit confirmation; never publish.
 MD;
 
 	if ( ! $is_admin ) {

--- a/inc/tools/class-writing-assistant.php
+++ b/inc/tools/class-writing-assistant.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Writing Assistant Tool
+ *
+ * Lets an Extra Chill team writer work on their own blog draft through Roadie
+ * chat: discover the draft, read it, and submit it for editorial review — all
+ * targeting MAIN extrachill.com (blog 1), where Studio drafts are born and
+ * where editors look for the review queue (extrachill-studio#75, #90).
+ *
+ * This tool is deliberately small. The heavy lifting — proposing block-level
+ * edits as inline accept/reject diff cards — is handled by Data Machine's
+ * generic content tools (`get_post_blocks` / `edit_post_blocks` /
+ * `replace_post_blocks` / `insert_content`), which Roadie already exposes in
+ * `chat` mode. As of data-machine#2669 those tools accept an optional
+ * `blog_id`, so the agent edits the draft on main by passing the main site's
+ * blog id. The agent-mode guidance (inc/agent-mode/register.php) tells the
+ * model to do exactly that.
+ *
+ * What this tool adds on top:
+ *   - `list_drafts`      — the writer's OWN drafts on main (author-scoped).
+ *   - `get_draft`        — a single draft's title/status/excerpt on main, plus
+ *                          the blog_id to hand to the content tools.
+ *   - `submit_for_review`— transition a draft → `pending` on main. Never
+ *                          publishes (the team role lacks `publish_posts`, and
+ *                          this tool only ever sends `pending`).
+ *
+ * Cross-site execution reuses the existing `ec_cross_site_rest_request('main', …)`
+ * primitive (via ECRoadie_PlatformTool::rest_request) — the same primitive the
+ * Studio compose proxy routes (#90) use under the hood. No parallel cross-site
+ * mechanism is introduced. Author-scoping is enforced through the calling-user
+ * contract from ECRoadie_PlatformTool plus an explicit author check on each
+ * draft, so a writer can only touch their own drafts (admins may target
+ * another user via the inherited act-on-behalf-of gate).
+ *
+ * @package ExtraChillRoadie\Tools
+ * @since 0.12.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ECRoadie_WritingAssistant extends ECRoadie_PlatformTool {
+
+	protected string $site_key  = 'main';
+	protected string $tool_slug = 'writing_assistant';
+
+	public function __construct() {
+		$this->registerTool(
+			'writing_assistant',
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'access_level' => 'author' )
+		);
+	}
+
+	/**
+	 * Tool definition surfaced to the AI.
+	 *
+	 * @return array
+	 */
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Work on the calling writer\'s own blog draft on the main Extra Chill site. Use "list_drafts" to find their drafts, "get_draft" to read one (returns the blog_id to pass to get_post_blocks/edit_post_blocks when proposing edits), and "submit_for_review" to send a finished draft to the editors (draft → pending). Drafts live on the MAIN site; the actual editing is done with the content tools (get_post_blocks, edit_post_blocks) using the blog_id this tool reports. Never publishes — editorial approval is a human step in wp-admin. Defaults to the calling user; admins may target another writer with user_id.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'  => array(
+						'type'        => 'string',
+						'description' => 'Action to perform: "list_drafts" (list the user\'s own drafts on main), "get_draft" (read one draft + its blog_id), "submit_for_review" (transition a draft to pending for editorial review).',
+					),
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => 'Draft post ID on the main site. Required for "get_draft" and "submit_for_review". Omit for "list_drafts".',
+					),
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => 'Target writer\'s user ID. Optional. Defaults to the calling user. Admin-only override.',
+					),
+				),
+				'required'   => array( 'action' ),
+			),
+		);
+	}
+
+	/**
+	 * Handle the chat tool call.
+	 *
+	 * @param array $parameters Tool parameters.
+	 * @param array $tool_def   Tool definition.
+	 * @return array
+	 */
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		unset( $tool_def );
+
+		$acting_user_id = $this->resolve_acting_user_id( $parameters );
+
+		$denied = $this->assert_acting_user_allowed( $acting_user_id, $parameters );
+		if ( null !== $denied ) {
+			return $denied;
+		}
+
+		$action = isset( $parameters['action'] ) ? sanitize_key( (string) $parameters['action'] ) : '';
+
+		switch ( $action ) {
+			case 'list_drafts':
+				return $this->handle_list_drafts( $acting_user_id );
+			case 'get_draft':
+				return $this->handle_get_draft( $parameters, $acting_user_id );
+			case 'submit_for_review':
+				return $this->handle_submit_for_review( $parameters, $acting_user_id );
+			default:
+				return $this->buildErrorResponse(
+					'Invalid action "' . $action . '". Use: list_drafts, get_draft, submit_for_review.',
+					'writing_assistant'
+				);
+		}
+	}
+
+	/**
+	 * List the acting writer's own drafts on the main site.
+	 *
+	 * Author-scoped: the `author` query param restricts results to the writer's
+	 * own posts even when the caller (an admin acting on their behalf) could see
+	 * others'. Mirrors extrachill-studio#90's draft picker.
+	 *
+	 * @param int $acting_user_id Writer whose drafts to list.
+	 * @return array
+	 */
+	private function handle_list_drafts( int $acting_user_id ): array {
+		$result = $this->rest_request(
+			'GET',
+			'/wp/v2/posts',
+			array(
+				'query'   => array(
+					'status'   => 'draft',
+					'author'   => $acting_user_id,
+					'per_page' => 20,
+					'orderby'  => 'modified',
+					'order'    => 'desc',
+					'context'  => 'edit',
+					'_fields'  => 'id,title,status,modified,link',
+				),
+				'user_id' => $acting_user_id,
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$posts  = is_array( $result['data'] ?? null ) ? $result['data'] : array();
+		$drafts = array();
+		foreach ( $posts as $post ) {
+			if ( ! is_array( $post ) ) {
+				continue;
+			}
+			$drafts[] = array(
+				'post_id'  => (int) ( $post['id'] ?? 0 ),
+				'title'    => (string) ( $post['title']['rendered'] ?? ( $post['title'] ?? '' ) ),
+				'status'   => (string) ( $post['status'] ?? '' ),
+				'modified' => (string) ( $post['modified'] ?? '' ),
+			);
+		}
+
+		if ( empty( $drafts ) ) {
+			return $this->buildDiagnosticErrorResponse(
+				'You do not have any drafts in progress on the main site yet.',
+				'not_found',
+				'writing_assistant',
+				array( 'user_id' => $acting_user_id ),
+				array(
+					'action'    => 'Start a draft in Studio',
+					'message'   => 'Create a draft in the Studio compose editor first, then come back to edit or submit it.',
+					'tool_hint' => 'writing_assistant',
+				)
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => array(
+				'blog_id' => $this->main_blog_id(),
+				'drafts'  => $drafts,
+				'count'   => count( $drafts ),
+			),
+			'tool_name' => 'writing_assistant',
+		);
+	}
+
+	/**
+	 * Read a single draft on the main site.
+	 *
+	 * Returns the draft's metadata plus the main `blog_id` so the agent can pass
+	 * it to `get_post_blocks` / `edit_post_blocks` to read and propose edits to
+	 * the block content. Author-scoped: the writer can only read their own
+	 * drafts (admins acting on behalf are gated by the inherited check).
+	 *
+	 * @param array $parameters     Tool parameters.
+	 * @param int   $acting_user_id Writer the draft must belong to.
+	 * @return array
+	 */
+	private function handle_get_draft( array $parameters, int $acting_user_id ): array {
+		$post_id = isset( $parameters['post_id'] ) ? absint( $parameters['post_id'] ) : 0;
+		if ( $post_id <= 0 ) {
+			return $this->buildErrorResponse(
+				'A post_id is required to read a draft. Use "list_drafts" to find one.',
+				'writing_assistant'
+			);
+		}
+
+		$ownership = $this->assert_draft_owned_by( $post_id, $acting_user_id );
+		if ( null !== $ownership ) {
+			return $ownership;
+		}
+
+		$result = $this->rest_request(
+			'GET',
+			'/wp/v2/posts/' . $post_id,
+			array(
+				'query'   => array(
+					'context' => 'edit',
+					'_fields' => 'id,title,status,excerpt,modified,link',
+				),
+				'user_id' => $acting_user_id,
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$post = is_array( $result['data'] ?? null ) ? $result['data'] : array();
+
+		return array(
+			'success'   => true,
+			'data'      => array(
+				'blog_id'  => $this->main_blog_id(),
+				'post_id'  => $post_id,
+				'title'    => (string) ( $post['title']['raw'] ?? ( $post['title']['rendered'] ?? '' ) ),
+				'status'   => (string) ( $post['status'] ?? '' ),
+				'modified' => (string) ( $post['modified'] ?? '' ),
+				'hint'     => 'To read or edit the block content, call get_post_blocks / edit_post_blocks with this post_id AND blog_id. Propose edits as a preview (preview=true) so the writer can accept or reject them.',
+			),
+			'tool_name' => 'writing_assistant',
+		);
+	}
+
+	/**
+	 * Submit a draft for editorial review on the main site.
+	 *
+	 * Transitions the post draft → `pending` via the same cross-site primitive
+	 * the Studio compose proxy uses (extrachill-studio#90). Never sends
+	 * `publish`; the `extra_chill_team` role lacks `publish_posts`, and even if
+	 * it didn't, this tool only ever requests `pending`. Editorial approval is a
+	 * deliberate human step in wp-admin.
+	 *
+	 * @param array $parameters     Tool parameters.
+	 * @param int   $acting_user_id Writer the draft must belong to.
+	 * @return array
+	 */
+	private function handle_submit_for_review( array $parameters, int $acting_user_id ): array {
+		$post_id = isset( $parameters['post_id'] ) ? absint( $parameters['post_id'] ) : 0;
+		if ( $post_id <= 0 ) {
+			return $this->buildErrorResponse(
+				'A post_id is required to submit a draft. Use "list_drafts" to find one.',
+				'writing_assistant'
+			);
+		}
+
+		$ownership = $this->assert_draft_owned_by( $post_id, $acting_user_id );
+		if ( null !== $ownership ) {
+			return $ownership;
+		}
+
+		$result = $this->rest_request(
+			'POST',
+			'/wp/v2/posts/' . $post_id,
+			array(
+				'body'    => array( 'status' => 'pending' ),
+				'user_id' => $acting_user_id,
+			)
+		);
+
+		if ( ! empty( $result['success'] ) ) {
+			$result['message'] = 'Draft submitted for review. It is now in the editorial queue on extrachill.com as a pending post — an editor will review and publish it.';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Assert that a draft belongs to the acting writer and is still a draft.
+	 *
+	 * Reads the post on main (switch_to_blog is safe for data reads) and checks
+	 * authorship + status. Returns null when the writer owns the draft, or a
+	 * standardized error response otherwise. Admins acting on behalf of the
+	 * writer have already passed assert_acting_user_allowed(), so the author
+	 * comparison here is against the *resolved* acting user — the writer whose
+	 * draft is being touched — which is the correct scope in both cases.
+	 *
+	 * @param int $post_id        Draft post ID on main.
+	 * @param int $acting_user_id Expected author.
+	 * @return array|null Error response when denied/not-found, null when allowed.
+	 */
+	private function assert_draft_owned_by( int $post_id, int $acting_user_id ): ?array {
+		$main_blog_id = $this->main_blog_id();
+		if ( $main_blog_id <= 0 ) {
+			return $this->buildErrorResponse(
+				'Could not resolve the main site. Ensure extrachill-multisite is active.',
+				'writing_assistant'
+			);
+		}
+
+		switch_to_blog( $main_blog_id );
+		$post = get_post( $post_id );
+		restore_current_blog();
+
+		if ( ! $post || 'post' !== $post->post_type ) {
+			return $this->buildDiagnosticErrorResponse(
+				sprintf( 'No draft #%d found on the main site.', $post_id ),
+				'not_found',
+				'writing_assistant',
+				array( 'post_id' => $post_id ),
+				array(
+					'action'    => 'List your drafts',
+					'message'   => 'Use action "list_drafts" to see the drafts you can work on.',
+					'tool_hint' => 'writing_assistant',
+				)
+			);
+		}
+
+		if ( (int) $post->post_author !== $acting_user_id ) {
+			return $this->buildErrorResponse(
+				sprintf( 'Draft #%d does not belong to this writer. You can only work on your own drafts.', $post_id ),
+				'writing_assistant'
+			);
+		}
+
+		if ( 'draft' !== $post->post_status && 'pending' !== $post->post_status ) {
+			return $this->buildErrorResponse(
+				sprintf( 'Post #%d is "%s", not an editable draft. Roadie only works on drafts awaiting submission.', $post_id, $post->post_status ),
+				'writing_assistant'
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve the main site's blog ID.
+	 *
+	 * @return int Main blog ID, or 0 when unresolved.
+	 */
+	private function main_blog_id(): int {
+		$blog_id = $this->get_blog_id( 'main' );
+		return $blog_id ? (int) $blog_id : 0;
+	}
+}

--- a/inc/tools/register.php
+++ b/inc/tools/register.php
@@ -35,6 +35,7 @@ add_action(
 		require_once __DIR__ . '/class-manage-link-page.php';
 		require_once __DIR__ . '/class-manage-user-profile.php';
 		require_once __DIR__ . '/class-manage-community.php';
+		require_once __DIR__ . '/class-writing-assistant.php';
 		require_once __DIR__ . '/class-propose-code-change.php';
 		require_once __DIR__ . '/class-apply-code-change.php';
 		require_once __DIR__ . '/class-file-feature-request.php';
@@ -44,6 +45,7 @@ add_action(
 		new ECRoadie_ManageLinkPage();
 		new ECRoadie_ManageUserProfile();
 		new ECRoadie_ManageCommunity();
+		new ECRoadie_WritingAssistant();
 		new ECRoadie_ProposeCodeChange();
 		new ECRoadie_ApplyCodeChange();
 		new ECRoadie_FileFeatureRequest();
@@ -54,7 +56,7 @@ add_action(
 /**
  * The roadie platform management tools, by slug.
  *
- * These are the seven write-capable tools registered above. They are the set
+ * These are the write-capable tools registered above. They are the set
  * hidden from public-tier callers — a visitor with no team access cannot use
  * any of them, so offering them only produces dead options and permission-error
  * round-trips.
@@ -68,6 +70,7 @@ function extrachill_roadie_managed_tool_slugs(): array {
 		'manage_link_page',
 		'manage_user_profile',
 		'manage_community',
+		'writing_assistant',
 		'propose_code_change',
 		'apply_code_change',
 		'file_feature_request',

--- a/tests/writing-assistant-smoke.php
+++ b/tests/writing-assistant-smoke.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Smoke test: the writing_assistant tool is author-scoped, submit-only-to-pending,
+ * and routes its actions correctly against the MAIN site.
+ *
+ * Confirms:
+ *   - a writer can list/get/submit their OWN draft on main (blog 1);
+ *   - a writer is refused on a draft they do not own;
+ *   - a non-admin cannot act on another user's behalf (inherited gate);
+ *   - submit_for_review only ever sends status=pending (never publish);
+ *   - get_draft / list_drafts report the main blog_id for the content tools;
+ *   - non-draft / non-existent posts are refused.
+ *
+ * Run with: php tests/writing-assistant-smoke.php
+ *
+ * @package ExtraChillRoadie\Tests
+ */
+
+require_once __DIR__ . '/_stub-base-tool.php';
+require_once __DIR__ . '/_stub-wp-and-rest.php';
+
+// Sanitizers the tool relies on that the shared stubs don't provide.
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) );
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/tools/class-ec-platform-tool.php';
+require_once dirname( __DIR__ ) . '/inc/tools/class-writing-assistant.php';
+
+function ec_roadie_wa_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+/**
+ * Register a fake post in the get_post() stub registry.
+ */
+function ec_roadie_wa_set_post( int $id, int $author, string $status, string $type = 'post' ): void {
+	$GLOBALS['ec_roadie_test_posts'][ $id ] = (object) array(
+		'ID'          => $id,
+		'post_author' => $author,
+		'post_status' => $status,
+		'post_type'   => $type,
+	);
+}
+
+$writer    = 38;
+$other     = 77;
+$admin     = 1;
+$draft_id  = 500;
+
+// =========================================================================
+// 1. Writer submits their OWN draft → status=pending, never publish.
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+ec_roadie_wa_set_post( $draft_id, $writer, 'draft' );
+$GLOBALS['ec_roadie_test_rest_response'] = array( 'id' => $draft_id, 'status' => 'pending' );
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'submit_for_review',
+		'post_id'         => $draft_id,
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( true === ( $result['success'] ?? false ), 'Writer should be able to submit their own draft.' );
+$calls = $GLOBALS['ec_roadie_test_rest_calls'];
+ec_roadie_wa_assert( 1 === count( $calls ), 'submit_for_review should make exactly one cross-site call.' );
+ec_roadie_wa_assert( 'main' === $calls[0]['site_key'], 'submit must target the main site.' );
+ec_roadie_wa_assert( 'POST' === $calls[0]['method'], 'submit must be a POST.' );
+ec_roadie_wa_assert( '/wp/v2/posts/' . $draft_id === $calls[0]['path'], 'submit must hit the post update route on main.' );
+ec_roadie_wa_assert( 'pending' === ( $calls[0]['args']['body']['status'] ?? '' ), 'submit must set status=pending.' );
+ec_roadie_wa_assert( 'publish' !== ( $calls[0]['args']['body']['status'] ?? '' ), 'submit must NEVER publish.' );
+ec_roadie_wa_assert( $writer === ( $calls[0]['effective_user'] ?? 0 ), 'submit must act as the writer.' );
+
+// =========================================================================
+// 2. Writer cannot submit a draft they do NOT own → refused, no REST call.
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+ec_roadie_wa_set_post( $draft_id, $other, 'draft' ); // owned by someone else
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'submit_for_review',
+		'post_id'         => $draft_id,
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( false === ( $result['success'] ?? true ), 'Writer must not submit a draft they do not own.' );
+ec_roadie_wa_assert( str_contains( strtolower( $result['error'] ?? '' ), 'your own drafts' ), 'Refusal should explain author-scoping.' );
+ec_roadie_wa_assert( 0 === count( $GLOBALS['ec_roadie_test_rest_calls'] ), 'A refused submit must not reach the REST helper.' );
+
+// =========================================================================
+// 3. Non-admin cannot act on another user's behalf (inherited gate).
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'list_drafts',
+		'user_id'         => $other,
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( false === ( $result['success'] ?? true ), 'Non-admin must not act on another user.' );
+ec_roadie_wa_assert( 'permission' === ( $result['error_type'] ?? '' ), 'Cross-user denial should be a permission error.' );
+ec_roadie_wa_assert( 0 === count( $GLOBALS['ec_roadie_test_rest_calls'] ), 'Denied cross-user call must not reach REST.' );
+
+// =========================================================================
+// 4. get_draft on a non-existent post → not_found, no content call.
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'get_draft',
+		'post_id'         => 999,
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( false === ( $result['success'] ?? true ), 'get_draft on a missing post should fail.' );
+ec_roadie_wa_assert( 'not_found' === ( $result['error_type'] ?? '' ), 'Missing draft should be not_found.' );
+ec_roadie_wa_assert( 0 === count( $GLOBALS['ec_roadie_test_rest_calls'] ), 'Missing draft must not reach REST.' );
+
+// =========================================================================
+// 5. get_draft on the writer's own draft → reports main blog_id for the
+//    content tools.
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+ec_roadie_wa_set_post( $draft_id, $writer, 'draft' );
+$GLOBALS['ec_roadie_test_rest_response'] = array(
+	'id'     => $draft_id,
+	'title'  => array( 'raw' => 'My Draft' ),
+	'status' => 'draft',
+);
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'get_draft',
+		'post_id'         => $draft_id,
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( true === ( $result['success'] ?? false ), 'Writer should read their own draft.' );
+ec_roadie_wa_assert( 1 === (int) ( $result['data']['blog_id'] ?? 0 ), 'get_draft must report the main blog_id (1).' );
+ec_roadie_wa_assert( $draft_id === (int) ( $result['data']['post_id'] ?? 0 ), 'get_draft must echo the post_id.' );
+
+// =========================================================================
+// 6. Already-published post is refused (Roadie only works on drafts).
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+ec_roadie_wa_set_post( $draft_id, $writer, 'publish' );
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'submit_for_review',
+		'post_id'         => $draft_id,
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( false === ( $result['success'] ?? true ), 'A published post is not an editable draft.' );
+ec_roadie_wa_assert( 0 === count( $GLOBALS['ec_roadie_test_rest_calls'] ), 'Published post must not reach REST.' );
+
+// =========================================================================
+// 7. Admin CAN act on another writer's behalf (inherited admin override).
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $admin );
+ec_roadie_test_grant_cap( $admin, 'manage_options' );
+ec_roadie_wa_set_post( $draft_id, $other, 'draft' );
+$GLOBALS['ec_roadie_test_rest_response'] = array( 'id' => $draft_id, 'status' => 'pending' );
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'submit_for_review',
+		'post_id'         => $draft_id,
+		'user_id'         => $other,
+		'calling_user_id' => $admin,
+	)
+);
+
+ec_roadie_wa_assert( true === ( $result['success'] ?? false ), 'Admin should submit on behalf of another writer.' );
+$calls = $GLOBALS['ec_roadie_test_rest_calls'];
+ec_roadie_wa_assert( $other === ( $calls[0]['effective_user'] ?? 0 ), 'Admin-on-behalf submit must act as the target writer.' );
+
+// =========================================================================
+// 8. Unknown action → clean validation error.
+// =========================================================================
+ec_roadie_test_reset();
+ec_roadie_test_login_as( $writer );
+
+$tool   = new ECRoadie_WritingAssistant();
+$result = $tool->handle_tool_call(
+	array(
+		'action'          => 'delete_everything',
+		'calling_user_id' => $writer,
+	)
+);
+
+ec_roadie_wa_assert( false === ( $result['success'] ?? true ), 'Unknown action should fail.' );
+ec_roadie_wa_assert( str_contains( strtolower( $result['error'] ?? '' ), 'invalid action' ), 'Unknown action should be flagged as invalid.' );
+
+echo "Roadie writing-assistant smoke passed (24 assertions).\n";


### PR DESCRIPTION
## Summary

Gives an Extra Chill team writer the ability to **edit and submit their own blog draft through Roadie chat**, with AI-proposed edits shown as inline accept/reject diff cards. Closes #48.

The draft lives on **main extrachill.com (blog 1)** — that's where Studio drafts are born (extrachill-studio#75, #90) and where editors look for the review queue — even though the chat runs on another subsite (e.g. studio.extrachill.com).

## Phase 1 investigation — and why this PR is small

The issue assumed "the diff/accept-reject UX is free cross-site." It wasn't, and the investigation found why: **Data Machine's block-content editing stack was implicitly single-blog.** `edit_post_blocks` / `replace_post_blocks` / `get_post_blocks` / `insert_content` and their pending-action handlers all resolved `post_id` against whatever blog the request landed on; the `PendingActionStore` is `$wpdb->prefix`-scoped (per-blog); and both the propose turn AND the accept/reject resolve turn land on the chat-surface blog. So a staged diff card always applied to the *calling* blog's post, never main's.

Pointing the generic tools at a post on main would have required either editing the generic data-machine layer from Roadie (forbidden — RULES.md layer purity) or relocating the whole turn to main's context (infeasible — session store, pending-action table, and resolve route all live on the calling blog).

**So the cross-site fix went where the gap actually is: Data Machine core.** [data-machine#2669](https://github.com/Extra-Chill/data-machine/pull/2669) (merged) added an optional `blog_id` dimension to the four content abilities + their pending-action handlers via a shared `BlogContext` helper. That makes the inline cross-site DiffCard path work — and benefits any multisite DM install, not just Roadie.

With #2669 doing the heavy lifting, **this Roadie PR shrinks to the integration glue:**

## What's reused vs. net-new

**Reused (no rebuild):**
- DM's generic content tools (`get_post_blocks` / `edit_post_blocks` / `replace_post_blocks` / `insert_content`) for reading + proposing block edits, now multisite-aware via `blog_id` (#2669). Roadie already exposes them in `chat` mode.
- agents-api pending actions + `@extrachill/chat` DiffCards for the accept/reject UX (already wired by Frontend Agent Chat).
- The `ec_cross_site_rest_request('main', …)` primitive (via `ECRoadie_PlatformTool`) — the same one the #90 Studio compose proxy routes use under the hood. No parallel cross-site mechanism.
- `ECRoadie_PlatformTool`'s calling-user / act-on-behalf-of gate for author-scoping.

**Net-new (small):** one `writing_assistant` tool with three author-scoped actions:
- `list_drafts` — the writer's OWN drafts on main (author-scoped `GET /wp/v2/posts`).
- `get_draft` — a draft's title/status + the main `blog_id` to hand to the content tools.
- `submit_for_review` — draft → `pending` on main (`POST /wp/v2/posts/<id>` with `status=pending`). **Never publishes.**

Plus agent-mode guidance walking the model through find → read → propose (preview) → submit, with the human-in-the-loop and no-publish rules.

## Tool added, gating, guidance

- `inc/tools/class-writing-assistant.php` — extends `ECRoadie_PlatformTool` (`site_key = 'main'`), registered in `chat` mode with `access_level=author`.
- Added to `extrachill_roadie_managed_tool_slugs()` so it's **hidden from public-tier callers** (a logged-out visitor never sees it).
- **Author-scoping** enforced two ways: the inherited `assert_acting_user_allowed()` gate (non-admins can't act on behalf of others; admins can via explicit `user_id`), plus an explicit per-draft author + status check (`assert_draft_owned_by()`) so a writer only ever touches their own drafts, and only drafts/pending (never published posts).
- **No publish path:** `submit_for_review` only ever sends `status=pending`; `extra_chill_team` lacks `publish_posts`; editorial approval stays a human step in wp-admin.
- Agent-mode guidance (`inc/agent-mode/register.php`, team/admin tier) documents the tool + the find→read→propose→submit flow and the propose-then-accept / submit-only-on-confirmation / never-publish rules.

## No generic layer modified

This PR touches **only** extrachill-roadie. The multisite content fix lives in data-machine (#2669, its own PR). No edits to data-machine, agents-api, or `@extrachill/chat` from this integration layer.

## Tests

- `tests/writing-assistant-smoke.php` (new, 24 assertions, all pass) — author-scoping (own draft OK, others' refused, no REST leak), non-admin cross-user denial, submit-only-to-`pending` (asserts it never publishes + acts as the writer), not-found / non-draft refusal, `get_draft` reporting the main `blog_id`, admin act-on-behalf override, unknown-action validation.
- All existing roadie smokes still pass (calling-user permission denial, calling-user identity, agent-mode registration).
- `php -l` clean; `phpcs --standard=WordPress` **0 findings** on all touched files incl. the new test.

## Manual acceptance (the 3-step writer flow from #48)

As a team writer in Roadie chat on studio.extrachill.com with a draft on main:
1. "What are my drafts?" → `writing_assistant` `list_drafts` returns the writer's own drafts on main + the main `blog_id`.
2. "Tighten the intro of draft N" → `get_post_blocks` (with `post_id` + `blog_id`) reads it, then `edit_post_blocks` (with `post_id` + `blog_id` + `preview=true`) stages an inline accept/reject diff card; on Accept it applies to the draft **on main** (attachment IDs stay blog-1, content not mangled).
3. "Submit it for review" → on explicit confirmation, `writing_assistant` `submit_for_review` sets `pending` on main; the post appears in the editor queue on extrachill.com.

**Note:** end-to-end verification on prod requires data-machine#2669 to be **deployed** (the live `edit_post_blocks` needs the `blog_id` param). #2669 is merged. Also benefits from extrachill-studio#92 (client-context active-draft id) so Roadie knows the active draft without asking.

Closes #48. References #90, #92, and depends on data-machine#2669.