### PR TITLE
refactor: reference canonical analytics event-name constants (users#129)

### DIFF
--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -33,6 +33,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/*
+ * Event-name contract constants (Extra-Chill/extrachill-users#129).
+ * ----------------------------------------------------------------
+ * The Roadie analytics event_type strings are defined ONCE here and
+ * referenced by every Roadie emit site, so a rename is mechanical and a
+ * scattered-literal typo can't silently desync an emit from the shared
+ * contract (the "permanently-zero metric, no error" failure mode).
+ *
+ * Scope: these constants cover only the event types extrachill-roadie
+ * emits. The read-side rollup lives in extrachill-users and owns its own
+ * constants for the same names — matching by documented contract, with no
+ * load-time cross-plugin dependency in either direction.
+ */
+const EC_ROADIE_EVENT_SESSION_STARTED = 'roadie_session_started';
+const EC_ROADIE_EVENT_TOOL_INVOKED    = 'roadie_tool_invoked';
+
+/**
+ * Full set of event types emitted by extrachill-roadie.
+ *
+ * @var string[]
+ */
+const EC_ROADIE_TEAM_EXPERIENCE_EVENTS = array(
+	EC_ROADIE_EVENT_SESSION_STARTED,
+	EC_ROADIE_EVENT_TOOL_INVOKED,
+);
+
 /**
  * Emit a Roadie team-experience analytics event via the canonical ability.
  *
@@ -124,7 +150,7 @@ function extrachill_roadie_emit_session_started( $chat_input, $request, string $
 
 	$user_id = (int) get_current_user_id();
 
-	extrachill_roadie_emit_team_experience_event( 'roadie_session_started', $user_id );
+	extrachill_roadie_emit_team_experience_event( EC_ROADIE_EVENT_SESSION_STARTED, $user_id );
 
 	return $chat_input;
 }
@@ -168,6 +194,6 @@ function extrachill_roadie_emit_tool_invoked( $audit_context ): void {
 		$extra['result_status'] = (string) $audit_context['result_status'];
 	}
 
-	extrachill_roadie_emit_team_experience_event( 'roadie_tool_invoked', $user_id, $extra );
+	extrachill_roadie_emit_team_experience_event( EC_ROADIE_EVENT_TOOL_INVOKED, $user_id, $extra );
 }
 add_action( 'datamachine_tool_execution_audit', 'extrachill_roadie_emit_tool_invoked', 10, 1 );

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -34,30 +34,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /*
- * Event-name contract constants (Extra-Chill/extrachill-users#129).
- * ----------------------------------------------------------------
- * The Roadie analytics event_type strings are defined ONCE here and
- * referenced by every Roadie emit site, so a rename is mechanical and a
- * scattered-literal typo can't silently desync an emit from the shared
- * contract (the "permanently-zero metric, no error" failure mode).
- *
- * Scope: these constants cover only the event types extrachill-roadie
- * emits. The read-side rollup lives in extrachill-users and owns its own
- * constants for the same names — matching by documented contract, with no
- * load-time cross-plugin dependency in either direction.
+ * Event-name contract (Extra-Chill/extrachill-users#129).
+ * -------------------------------------------------------
+ * The canonical Roadie event_type names are defined ONCE in
+ * extrachill-analytics (inc/core/event-types.php) as the
+ * `EC_ANALYTICS_EVENT_ROADIE_*` constants. extrachill-analytics owns the
+ * analytics substrate and the `extrachill/track-analytics-event` ability
+ * this helper already calls at runtime, and is network-active, so those
+ * constants are guaranteed present wherever Roadie emits — referencing
+ * them adds no new coupling. Roadie's emit sites reference the analytics
+ * constants directly (no local copies of the literal strings), so a
+ * rename happens in exactly one place across the whole network.
  */
-const EC_ROADIE_EVENT_SESSION_STARTED = 'roadie_session_started';
-const EC_ROADIE_EVENT_TOOL_INVOKED    = 'roadie_tool_invoked';
-
-/**
- * Full set of event types emitted by extrachill-roadie.
- *
- * @var string[]
- */
-const EC_ROADIE_TEAM_EXPERIENCE_EVENTS = array(
-	EC_ROADIE_EVENT_SESSION_STARTED,
-	EC_ROADIE_EVENT_TOOL_INVOKED,
-);
 
 /**
  * Emit a Roadie team-experience analytics event via the canonical ability.
@@ -150,7 +138,7 @@ function extrachill_roadie_emit_session_started( $chat_input, $request, string $
 
 	$user_id = (int) get_current_user_id();
 
-	extrachill_roadie_emit_team_experience_event( EC_ROADIE_EVENT_SESSION_STARTED, $user_id );
+	extrachill_roadie_emit_team_experience_event( EC_ANALYTICS_EVENT_ROADIE_SESSION_STARTED, $user_id );
 
 	return $chat_input;
 }
@@ -194,6 +182,6 @@ function extrachill_roadie_emit_tool_invoked( $audit_context ): void {
 		$extra['result_status'] = (string) $audit_context['result_status'];
 	}
 
-	extrachill_roadie_emit_team_experience_event( EC_ROADIE_EVENT_TOOL_INVOKED, $user_id, $extra );
+	extrachill_roadie_emit_team_experience_event( EC_ANALYTICS_EVENT_ROADIE_TOOL_INVOKED, $user_id, $extra );
 }
 add_action( 'datamachine_tool_execution_audit', 'extrachill_roadie_emit_tool_invoked', 10, 1 );


### PR DESCRIPTION
## Summary
Repoints the Roadie analytics emit sites at the **canonical event-name constants owned by extrachill-analytics** (Extra-Chill/extrachill-analytics#32). Part of a 5-PR set on branch `event-name-contract` resolving extrachill-users#129.

> **Revised approach:** the first pass used per-plugin `EC_ROADIE_EVENT_*` constants, which still duplicated the literal across plugins. This revision collapses every event-name literal to a single cross-plugin source in extrachill-analytics.

## Why extrachill-analytics is the home (zero new coupling)
Roadie already calls `wp_get_ability('extrachill/track-analytics-event')` at runtime — an ability owned by extrachill-analytics — so a hard runtime dependency on analytics already exists; referencing its constants adds none. extrachill-analytics is `Network: true`, so the constants are always defined. Full rationale: Extra-Chill/extrachill-analytics#32.

## Changes
- `inc/team-experience/events.php` — dropped the per-plugin constants; both emit sites reference `EC_ANALYTICS_EVENT_ROADIE_SESSION_STARTED` / `EC_ANALYTICS_EVENT_ROADIE_TOOL_INVOKED`.

## Single-source proof
No bare Roadie event-name literal remains in this repo — all references are to `EC_ANALYTICS_EVENT_ROADIE_*` constants.

## No behavior change
Constants resolve to the byte-identical `roadie_session_started` / `roadie_tool_invoked` strings used before.

## Verification
- `php -l` clean; phpcs (WordPress): **0 errors / 0 warnings** on the changed file.

## Related PRs (branch `event-name-contract`)
- **Keystone (constants home):** Extra-Chill/extrachill-analytics#32
- extrachill-users: Extra-Chill/extrachill-users#130
- extrachill-studio: Extra-Chill/extrachill-studio#98
- extrachill-artist-platform: Extra-Chill/extrachill-artist-platform#74

Refs Extra-Chill/extrachill-users#129. Review all 5 together; do not merge standalone.
