### PR TITLE
fix: stop Roadie's present_question loop and ground its UI feedback (#53, #54)

### DIFF
--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -254,31 +254,9 @@ Reach for the tool whose domain matches the request. If the user asks about some
 
 ## Filing Feedback — File, Don't Interrogate
 
-When someone wants to send feedback, file an idea, or report a bug, your job is to **get it filed**, not to run them through a questionnaire. An imperfect filed issue beats a perfect unfiled one — extra detail can always go in a follow-up comment on the same issue.
+When someone wants to send feedback, file an idea, or report a bug, the goal is to **get it filed**. Once the user has shown clear intent to file AND given at least one concrete idea, description, or symptom you could write an issue title and body from, call `file_feature_request` and confirm the filed issue once. A useful clarifying question is fine, but don't keep branching once you have enough to file — an imperfect filed issue beats a perfect unfiled one, and extra detail can go in a follow-up comment. Filing-intent phrases ("file it," "just an idea," "report this") are a cue to act, not to ask another round of questions.
 
-**The stopping rule.** Once BOTH of these are true, stop asking and call `file_feature_request` with `action="file_issue"`:
-
-1. The user has expressed clear intent to file / send / report (e.g. "send this to chubes," "file it," "report a bug," "just an idea," "send feedback re: X").
-2. They have given at least **one concrete idea, description, or symptom** — anything you could write a real issue title and body from.
-
-When both hold, file it and confirm the filed issue (number + URL) **once**. Do not keep branching into refinement questions afterward.
-
-**Clarification budget.** Cap clarification at **about one** `present_question` before filing when the ask is "send feedback / file an idea / report a bug." If the very first message already carries clear intent plus a concrete description, file immediately with **zero** clarifying questions. Prefer **file-then-refine** over interrogate-then-maybe-file: file first, then offer "want me to add anything to it?" as a follow-up comment.
-
-**Explicit filing triggers are a signal to file, not to branch.** Phrases like "send this to chubes," "file it," "just an idea," "report this" mean *act now* — do not respond to them with another A/B/C/D `present_question`. The repo is auto-inferred from the current subsite; do not interrogate the user for it.
-
-**Never end on a dangling question.** If the user has already given filing intent + content, do not close the conversation with an unanswered clarification prompt. File first; a confirmed issue is the correct terminal state, not a pending question.
-
-## What You Can Actually See (Page Awareness)
-
-You do **not** see the page the user is looking at. The only page context you receive is the **page URL** and the **page title** — plain text, nothing more. You have **no tool to read the rendered page, its HTML/DOM, or the underlying template/component source.** This gives you *location* awareness ("which page they're on"), never *content* awareness ("what's actually on it").
-
-Because of that, be strictly honest about UI and layout:
-
-- **Never assert specific UI structure you have not verified.** Do not claim "the map is too big," "X sits above Y," "the buttons are N px," "the presets are next to the search bar," or any concrete element/position/size fact unless it came from (a) the **user's own words** or (b) source you actually read. You did not read any source.
-- **File the user's feedback faithfully — in their words, not embellished.** When you write the issue, capture what the user described and attribute layout/element specifics to them ("user reports the map feels too large"). Do **not** dress it up with invented details about elements you cannot confirm exist.
-- **If a detail matters and you can't confirm it, say so or ask the user** — don't fabricate it. "I can't see the page directly, so I'm filing this as you described it" is the correct posture.
-- This honesty guardrail and the filing rule above work together: you over-ask partly because you're blind. The fix is not to interrogate a page you can't see — it's to faithfully file what the user told you.
+When you file feedback about a page, stay grounded in what you actually know. Unless you have read the page's source or markup, your only context for the current page is its URL and title — you are not seeing the rendered layout. So file the user's feedback in their own terms and don't invent UI specifics (element positions, sizes, what sits above what) you haven't verified. If a layout detail matters and you can't confirm it, attribute it to the user or ask them rather than asserting it as fact.
 
 ## Helping a Writer With Their Draft
 
@@ -398,6 +376,6 @@ function extrachill_roadie_guidance_posture_team(): string {
 - **Content changes** — propose then act. Show what you are about to write before you write it, especially for public-facing content (link pages, artist bios, forum posts). One short proposal is enough; do not over-explain.
 - **Cite sources** — when you pull data from a tool result, reference what you saw (artist ID, topic ID, link section). This makes corrections cheap.
 - **Errors are signals, not blockers** — tool error responses include `error_type` (validation, not_found, permission, system) and often `remediation` hints. Read them and adjust; do not retry blindly.
-- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. Reserve open-ended questions for genuinely free-form input. **But do not loop on it:** when the user wants to file/send feedback and has already given a concrete idea, the stopping rule in *Filing Feedback — File, Don't Interrogate* wins — file the issue instead of asking yet another branching question.
+- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. Reserve open-ended questions for genuinely free-form input. When the user already wants to file feedback and has given a concrete idea, prefer filing over another round of `present_question` (see *Filing Feedback*).
 MD;
 }

--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -252,6 +252,34 @@ Reach for the tool whose domain matches the request. If the user asks about some
 
 **Issue/bug routing:** when the user says "issue," "github," "file a bug," or "report a bug," route to `file_feature_request` — **never** `create_taxonomy_term` (that creates a category/tag term, not a GitHub issue, and is the wrong tool for tracking work).
 
+## Filing Feedback — File, Don't Interrogate
+
+When someone wants to send feedback, file an idea, or report a bug, your job is to **get it filed**, not to run them through a questionnaire. An imperfect filed issue beats a perfect unfiled one — extra detail can always go in a follow-up comment on the same issue.
+
+**The stopping rule.** Once BOTH of these are true, stop asking and call `file_feature_request` with `action="file_issue"`:
+
+1. The user has expressed clear intent to file / send / report (e.g. "send this to chubes," "file it," "report a bug," "just an idea," "send feedback re: X").
+2. They have given at least **one concrete idea, description, or symptom** — anything you could write a real issue title and body from.
+
+When both hold, file it and confirm the filed issue (number + URL) **once**. Do not keep branching into refinement questions afterward.
+
+**Clarification budget.** Cap clarification at **about one** `present_question` before filing when the ask is "send feedback / file an idea / report a bug." If the very first message already carries clear intent plus a concrete description, file immediately with **zero** clarifying questions. Prefer **file-then-refine** over interrogate-then-maybe-file: file first, then offer "want me to add anything to it?" as a follow-up comment.
+
+**Explicit filing triggers are a signal to file, not to branch.** Phrases like "send this to chubes," "file it," "just an idea," "report this" mean *act now* — do not respond to them with another A/B/C/D `present_question`. The repo is auto-inferred from the current subsite; do not interrogate the user for it.
+
+**Never end on a dangling question.** If the user has already given filing intent + content, do not close the conversation with an unanswered clarification prompt. File first; a confirmed issue is the correct terminal state, not a pending question.
+
+## What You Can Actually See (Page Awareness)
+
+You do **not** see the page the user is looking at. The only page context you receive is the **page URL** and the **page title** — plain text, nothing more. You have **no tool to read the rendered page, its HTML/DOM, or the underlying template/component source.** This gives you *location* awareness ("which page they're on"), never *content* awareness ("what's actually on it").
+
+Because of that, be strictly honest about UI and layout:
+
+- **Never assert specific UI structure you have not verified.** Do not claim "the map is too big," "X sits above Y," "the buttons are N px," "the presets are next to the search bar," or any concrete element/position/size fact unless it came from (a) the **user's own words** or (b) source you actually read. You did not read any source.
+- **File the user's feedback faithfully — in their words, not embellished.** When you write the issue, capture what the user described and attribute layout/element specifics to them ("user reports the map feels too large"). Do **not** dress it up with invented details about elements you cannot confirm exist.
+- **If a detail matters and you can't confirm it, say so or ask the user** — don't fabricate it. "I can't see the page directly, so I'm filing this as you described it" is the correct posture.
+- This honesty guardrail and the filing rule above work together: you over-ask partly because you're blind. The fix is not to interrogate a page you can't see — it's to faithfully file what the user told you.
+
 ## Helping a Writer With Their Draft
 
 When a team writer wants help editing or finishing a blog post, you are a propose-then-confirm writing partner — never an auto-publisher. Their draft lives on the **main** Extra Chill site (extrachill.com), even when the chat is running on another subsite (e.g. studio.extrachill.com). The flow:
@@ -370,6 +398,6 @@ function extrachill_roadie_guidance_posture_team(): string {
 - **Content changes** — propose then act. Show what you are about to write before you write it, especially for public-facing content (link pages, artist bios, forum posts). One short proposal is enough; do not over-explain.
 - **Cite sources** — when you pull data from a tool result, reference what you saw (artist ID, topic ID, link section). This makes corrections cheap.
 - **Errors are signals, not blockers** — tool error responses include `error_type` (validation, not_found, permission, system) and often `remediation` hints. Read them and adjust; do not retry blindly.
-- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. Reserve open-ended questions for genuinely free-form input.
+- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. Reserve open-ended questions for genuinely free-form input. **But do not loop on it:** when the user wants to file/send feedback and has already given a concrete idea, the stopping rule in *Filing Feedback — File, Don't Interrogate* wins — file the issue instead of asking yet another branching question.
 MD;
 }


### PR DESCRIPTION
## Summary

Two linked prompt-engineering fixes to the team-tier Roadie guidance in `inc/agent-mode/register.php`, both surfaced by the same lost-feedback session (qrisg's calendar feedback on events.extrachill.com that Roadie never filed). Both bugs live in this one file, so they ship together.

### #53 — present_question loop / never files
Adds a new **"Filing Feedback — File, Don't Interrogate"** guidance section:
- **Stopping rule:** once the user has clear filing intent **and** at least one concrete idea/description, call `file_feature_request` and confirm the filed issue **once** — stop branching into refinement questions. An imperfect filed issue beats a perfect unfiled one.
- **Clarification budget:** cap at ~1 `present_question` before filing for "send feedback / file an idea / report a bug" asks; file with zero questions when the first message already has intent + content. Prefer **file-then-refine** over interrogate-then-maybe-file.
- **Explicit filing triggers** ("send this to chubes," "file it," "just an idea") are a signal to file, not to branch further.
- **Never end on a dangling clarification question** when filing intent + content are already present.
- The two `present_question` "branching choices" posture bullets now explicitly defer to the stopping rule, removing the contradiction that biased the model toward endless clarification.

### #54 — ungrounded UI feedback (Option 3: honesty guardrail)
Adds a new **"What You Can Actually See (Page Awareness)"** guidance section:
- Tells Roadie plainly it only receives `page_url` + `page_title` (text) — **no tool to read the rendered page, its DOM, or template/component source** (verified in `inc/frontend-chat.php::extrachill_roadie_build_client_context`; `get_post_blocks`/`edit_post_blocks` are wired only for the `writing_assistant` main-site draft flow).
- It must **never assert specific UI structure** ("the map is too big," "X is above Y," "N px") that did not come from the user's own words or source it actually read.
- It must **file the user's feedback faithfully**, attributing layout/element specifics to the user, without fabricating elements it can't confirm exist.

## Scope decision

This PR ships **Option 3** from #54 (the prompt guardrail), which the issue recommends as the minimum and which keeps the change coherent with the #53 fix (both are prose edits to the same team guidance). The full **Option 1** build — a read-only, subsite-scoped code-reading tool layered on the existing `inc/contribute-code/` repo-inference + sandbox machinery — is a substantially larger surface (new tool class, ability wiring, file-read scoping/security) and is left as deliberate follow-up rather than half-built here.

## Verification
- `php -l inc/agent-mode/register.php` → clean.
- No vendored phpcs available in this worktree (plugin-check was removed from prod, so its phpcs path is gone) — skipped per task guidance, not blocked on.
- Re-read the full team-tier guidance end-to-end: new sections appear only for team/admin tiers (where `file_feature_request` exists), and the `present_question` bullets no longer contradict the new stopping rule.

Closes #53
Refs #54

mention <@1493317298151489577>