### PR TITLE
feat: infer GitHub repo from the page the user had open (page_url)

### DIFF
--- a/inc/contribute-code/subsite-context.php
+++ b/inc/contribute-code/subsite-context.php
@@ -247,3 +247,81 @@ function extrachill_roadie_detect_subsite_context( ?int $blog_id = null ): array
 	 */
 	return (array) apply_filters( 'extrachill_roadie_subsite_context', $context, $blog_id );
 }
+
+/**
+ * Resolve the blog id that owns a given front-end page URL.
+ *
+ * This is the page-aware complement to plain `get_current_blog_id()` repo
+ * inference. On the MAIN site (blog 1) the surviving subsite-specific surface
+ * spans several repos (theme, blog, seo, admin-tools), so "which blog is the
+ * REST request running on" is the wrong question — the request runs on
+ * whichever subsite the chat widget POSTs to, not necessarily the subsite the
+ * user actually had open. The page the user was viewing (page_url) is the
+ * disambiguating signal: a URL like `https://events.extrachill.com/calendar`
+ * unambiguously names the events subsite even when the chat turn executes on
+ * blog 1.
+ *
+ * Resolution is entirely WordPress-multisite-native and registry-free: the
+ * host (and path, for subdirectory networks) are matched against the network's
+ * registered sites via core `get_blog_id_from_url()`. There is NO plugin-name
+ * or brand-name special-casing here — page → blog is pure network topology,
+ * blog → repos stays driven by the slug-to-repo registry downstream. Adding a
+ * new subsite to the network is sufficient; no inference-code change is needed.
+ *
+ * @since 0.15.0
+ *
+ * @param string $page_url Front-end URL the user was viewing (from client context).
+ * @return int Resolved blog id, or 0 when the URL is empty, unparseable, or
+ *             does not belong to a registered network site.
+ */
+function extrachill_roadie_blog_id_from_page_url( string $page_url ): int {
+	$page_url = trim( $page_url );
+	if ( '' === $page_url ) {
+		return 0;
+	}
+
+	if ( ! function_exists( 'wp_parse_url' ) || ! function_exists( 'get_blog_id_from_url' ) ) {
+		return 0;
+	}
+
+	$parts = wp_parse_url( $page_url );
+	if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+		return 0;
+	}
+
+	$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+	if ( '' !== $scheme && ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+		return 0;
+	}
+
+	$host = strtolower( (string) $parts['host'] );
+
+	// Path matters only on subdirectory multisite networks. For subdomain
+	// networks (the EC topology) the path is always '/'. Normalize to a
+	// trailing-slashed path so get_blog_id_from_url() matches the site row,
+	// which stores paths with a trailing slash.
+	$path = (string) ( $parts['path'] ?? '/' );
+	$path = '' === $path ? '/' : $path;
+	if ( '/' !== substr( $path, -1 ) ) {
+		$path .= '/';
+	}
+
+	$blog_id = (int) get_blog_id_from_url( $host, $path );
+
+	// Subdirectory networks: a deep path (e.g. /events/calendar/) won't match
+	// the site row (path '/events/') on the first try. Walk the path down to
+	// its first segment so a deep URL still resolves to its owning subsite.
+	if ( 0 === $blog_id && '/' !== $path ) {
+		$segments = array_values( array_filter( explode( '/', $path ) ) );
+		while ( ! empty( $segments ) && 0 === $blog_id ) {
+			$candidate = '/' . implode( '/', $segments ) . '/';
+			$blog_id   = (int) get_blog_id_from_url( $host, $candidate );
+			array_pop( $segments );
+		}
+		if ( 0 === $blog_id ) {
+			$blog_id = (int) get_blog_id_from_url( $host, '/' );
+		}
+	}
+
+	return $blog_id;
+}

--- a/inc/tools/class-file-feature-request.php
+++ b/inc/tools/class-file-feature-request.php
@@ -55,7 +55,17 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 			$this->tool_slug,
 			array( $this, 'getToolDefinition' ),
 			array( 'chat' ),
-			array( 'access_level' => 'authenticated' )
+			array(
+				'access_level'            => 'authenticated',
+				// Bind the per-turn client-context page_url into the `page_url`
+				// parameter slot when the model doesn't pass one. inc/frontend-
+				// chat.php populates client_context['page_url'] from the widget;
+				// the runtime merges it here (caller-supplied value still wins,
+				// per WP_Agent_Tool_Parameters::buildParameters) so repo
+				// inference can prefer the subsite the user actually had open.
+				// Mirrors the exact mechanism inspect_page uses (#58).
+				'client_context_bindings' => array( 'page_url' => 'page_url' ),
+			)
 		);
 	}
 
@@ -66,10 +76,11 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	 */
 	public function getToolDefinition(): array {
 		return array(
-			'class'       => self::class,
-			'method'      => 'handle_tool_call',
-			'description' => 'When the user wants to track something on GitHub — a feature request, a bug report, or any "open an issue on github" / "file an issue" / "report a bug" ask — use this tool to file or look up GitHub issues against the appropriate Extra Chill repo. This is ALWAYS the right tool for filing GitHub issues; never use create_taxonomy_term (which makes a category/tag term, not a GitHub issue) for issue/bug-report requests. Three actions are supported: action="file_issue" creates a new issue (requires title, body; repo is optional and auto-inferred from the current subsite when omitted); action="list_recent_issues" finds existing open issues to dedupe against (optional repo/labels/state); action="comment_on_issue" adds a comment to an existing issue (requires issue_number, body; repo optional). When the user is chatting from the subsite that owns the code, leave repo unset and it will be inferred from page context — do not interrogate the user for the repo. Before filing new issues, prefer calling list_recent_issues first with a few keywords from the proposed title to surface duplicates and ask the user whether to comment on an existing thread instead. Use propose_code_change instead when the user wants the change implemented, not just tracked.',
-			'parameters'  => array(
+			'class'                   => self::class,
+			'method'                  => 'handle_tool_call',
+			'client_context_bindings' => array( 'page_url' => 'page_url' ),
+			'description'             => 'When the user wants to track something on GitHub — a feature request, a bug report, or any "open an issue on github" / "file an issue" / "report a bug" ask — use this tool to file or look up GitHub issues against the appropriate Extra Chill repo. This is ALWAYS the right tool for filing GitHub issues; never use create_taxonomy_term (which makes a category/tag term, not a GitHub issue) for issue/bug-report requests. Three actions are supported: action="file_issue" creates a new issue (requires title, body; repo is optional and auto-inferred from the current subsite when omitted); action="list_recent_issues" finds existing open issues to dedupe against (optional repo/labels/state); action="comment_on_issue" adds a comment to an existing issue (requires issue_number, body; repo optional). When the user is chatting from the subsite that owns the code, leave repo unset and it will be inferred from page context — do not interrogate the user for the repo. Before filing new issues, prefer calling list_recent_issues first with a few keywords from the proposed title to surface duplicates and ask the user whether to comment on an existing thread instead. Use propose_code_change instead when the user wants the change implemented, not just tracked.',
+			'parameters'              => array(
 				'type'       => 'object',
 				'required'   => array( 'action' ),
 				'properties' => array(
@@ -111,6 +122,10 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 					'per_page'     => array(
 						'type'        => 'integer',
 						'description' => 'How many recent issues to fetch with list_recent_issues. Defaults to 20, max 100.',
+					),
+					'page_url'     => array(
+						'type'        => 'string',
+						'description' => 'Optional. The page the user is currently viewing. Normally supplied automatically from chat client context (you do not need to set it); when present it disambiguates which subsite — and therefore which repo — an omitted repo should be inferred against. Pass it explicitly only if you know the user is referring to a different on-network page than the one they are on.',
 					),
 				),
 			),
@@ -157,7 +172,12 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 		$repo_inferred   = false;
 		$repo_candidates = array();
 		if ( '' === $repo ) {
-			$repo_candidates = $this->candidate_repos_from_context();
+			// The page the user actually had open (bound from client context
+			// via client_context_bindings) is the disambiguating signal for
+			// repo inference on the multi-repo main site. Caller-supplied repo
+			// still wins (handled by the '' === $repo guard above).
+			$page_url        = trim( (string) ( $parameters['page_url'] ?? '' ) );
+			$repo_candidates = $this->candidate_repos_from_context( $page_url );
 			$inferred        = $repo_candidates[0] ?? '';
 			if ( '' !== $inferred ) {
 				$repo          = $inferred;
@@ -294,11 +314,13 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	 * back to requiring an explicit `repo`.
 	 *
 	 * @since 0.11.0
+	 * @since 0.15.0 Accepts $page_url to prefer the viewed subsite.
 	 *
+	 * @param string $page_url Optional front-end URL the user was viewing.
 	 * @return string `owner/name` repo, or empty string when inference fails.
 	 */
-	protected function infer_repo_from_context(): string {
-		$candidates = $this->candidate_repos_from_context();
+	protected function infer_repo_from_context( string $page_url = '' ): string {
+		$candidates = $this->candidate_repos_from_context( $page_url );
 		return $candidates[0] ?? '';
 	}
 
@@ -321,18 +343,42 @@ class ECRoadie_FileFeatureRequest extends BaseTool {
 	 * excluding it from subsite-context detection is sufficient to make it a
 	 * candidate — no inference-code change required.
 	 *
-	 * @since 0.13.0
+	 * BLOG RESOLUTION (page-url repo inference): the blog whose context we detect
+	 * is preferentially the one that owns the page the user actually had open
+	 * (page_url), NOT just the blog the chat request happens to execute on.
+	 * The chat widget POSTs to a single REST endpoint, so a team member viewing
+	 * events.extrachill.com while the turn runs on blog 1 would otherwise get
+	 * blog-1 candidates — the exact ambiguity that forced Roadie to ASK which
+	 * repo. Resolving page_url → blog id (pure network topology, see
+	 * extrachill_roadie_blog_id_from_page_url) disambiguates without naming a
+	 * single plugin. Falls back to the executing blog when no page_url is
+	 * supplied or it doesn't resolve to a network site.
 	 *
+	 * @since 0.13.0
+	 * @since 0.15.0 Accepts $page_url to prefer the viewed subsite.
+	 *
+	 * @param string $page_url Optional front-end URL the user was viewing.
 	 * @return string[] Ordered, de-duplicated `owner/name` repos. Empty when
 	 *                  no subsite slug maps to a registered repo.
 	 */
-	protected function candidate_repos_from_context(): array {
+	protected function candidate_repos_from_context( string $page_url = '' ): array {
 		if ( ! function_exists( 'extrachill_roadie_detect_subsite_context' )
 			|| ! function_exists( 'extrachill_roadie_repo_for_slug' ) ) {
 			return array();
 		}
 
-		$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$blog_id = 0;
+
+		// Prefer the subsite that owns the page the user actually had open.
+		if ( '' !== $page_url && function_exists( 'extrachill_roadie_blog_id_from_page_url' ) ) {
+			$blog_id = extrachill_roadie_blog_id_from_page_url( $page_url );
+		}
+
+		// Fall back to the blog the chat turn is executing on.
+		if ( $blog_id <= 0 ) {
+			$blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		}
+
 		$context = extrachill_roadie_detect_subsite_context( $blog_id > 0 ? $blog_id : null );
 
 		$candidates = array();

--- a/tests/contribute-code-bootstrap.php
+++ b/tests/contribute-code-bootstrap.php
@@ -78,6 +78,16 @@ if ( ! function_exists( 'restore_current_blog' ) ) {
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( string $name, $default = false ) {
 		if ( 'active_plugins' === $name ) {
+			// Per-blog active-plugin map (set by tests that need to prove
+			// blog-resolution drives which subsite's plugins are read).
+			// Falls back to the flat list used by the rest of the suite.
+			$by_blog = $GLOBALS['extrachill_roadie_test_state']['active_plugins_by_blog'] ?? null;
+			if ( is_array( $by_blog ) ) {
+				$blog_id = (int) $GLOBALS['extrachill_roadie_test_state']['current_blog'];
+				if ( array_key_exists( $blog_id, $by_blog ) ) {
+					return $by_blog[ $blog_id ];
+				}
+			}
 			return $GLOBALS['extrachill_roadie_test_state']['active_plugins'];
 		}
 		return $GLOBALS['extrachill_roadie_test_state']['options'][ $name ] ?? $default;
@@ -120,6 +130,28 @@ if ( ! function_exists( 'get_current_user_id' ) ) {
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, int $flags = 0 ): string {
 		return (string) json_encode( $data, $flags );
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( string $url, int $component = -1 ) {
+		return parse_url( $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- test stub.
+	}
+}
+
+if ( ! function_exists( 'get_blog_id_from_url' ) ) {
+	/**
+	 * Test stub mirroring core multisite host+path → blog id resolution.
+	 *
+	 * Looks up the host/path pair in a test-controlled network site table at
+	 * $GLOBALS['extrachill_roadie_test_state']['network_sites'], shaped as
+	 * `[ 'host|/path/' => blog_id ]`. Returns 0 when no row matches, exactly
+	 * like core does for an off-network URL.
+	 */
+	function get_blog_id_from_url( string $host, string $path = '/' ): int {
+		$sites = $GLOBALS['extrachill_roadie_test_state']['network_sites'] ?? array();
+		$key   = strtolower( $host ) . '|' . $path;
+		return (int) ( $sites[ $key ] ?? 0 );
 	}
 }
 

--- a/tests/feature-request-tool.php
+++ b/tests/feature-request-tool.php
@@ -426,6 +426,129 @@ roadie_test_assert(
 	'disambiguation hint points the model at inspect_code to ground the owning component (#57)'
 );
 
+// --- page_url drives repo inference, not just the executing blog --------
+// The motivating bug (qrisg): a team member chatting from the main site
+// (blog 1, multi-repo, inherently ambiguous) about a specific subsite's page
+// was forced to name the repo because inference only looked at the executing
+// blog. page_url (the page the user actually had open) is the disambiguator.
+//
+// Set up a network site table so page_url → blog id resolves like core's
+// get_blog_id_from_url(), and give each blog its own active plugins so the
+// detector reads the VIEWED subsite's surface, not the executing one's.
+$GLOBALS['extrachill_roadie_test_state']['network_sites'] = array(
+	'extrachill.test|/'        => 1, // main site
+	'events.extrachill.test|/' => 7, // events subsite
+	'shop.extrachill.test|/'   => 3, // shop subsite
+);
+$GLOBALS['extrachill_roadie_test_state']['active_plugins_by_blog'] = array(
+	1 => array(),                                            // main site: no registered subsite plugin
+	7 => array( 'extrachill-events/extrachill-events.php' ), // events subsite
+	3 => array( 'extrachill-shop/extrachill-shop.php' ),     // shop subsite
+);
+
+// Chat turn EXECUTES on the main site (blog 1) but the user had the EVENTS
+// calendar open. Inference must follow page_url → events repo, not blog 1.
+$GLOBALS['extrachill_roadie_test_state']['current_blog']  = 1;
+$GLOBALS['extrachill_roadie_test_state']['ability_calls'] = array();
+
+$page_inferred = $tool->handle_tool_call( array(
+	'action'   => 'file_issue',
+	'title'    => 'Calendar filter bar wraps awkwardly on mobile',
+	'body'     => 'On the events calendar the tonight/this-weekend buttons wrap below the search box on narrow screens.',
+	'page_url' => 'https://events.extrachill.test/calendar/',
+) );
+roadie_test_assert( true === $page_inferred['success'], 'file_issue succeeds with repo inferred from page_url' );
+roadie_test_assert(
+	'Extra-Chill/extrachill-events' === ( $page_inferred['data']['repo'] ?? '' ),
+	'repo infers from the VIEWED subsite (page_url=events) even though the turn executes on blog 1. Got: ' . ( $page_inferred['data']['repo'] ?? '(none)' )
+);
+roadie_test_assert(
+	true === ( $page_inferred['data']['repo_inferred'] ?? false ),
+	'page_url-inferred repo is flagged repo_inferred'
+);
+$page_call = end( $GLOBALS['extrachill_roadie_test_state']['ability_calls'] );
+roadie_test_assert(
+	'Extra-Chill/extrachill-events' === ( $page_call['input']['repo'] ?? '' ),
+	'page_url-inferred repo is forwarded to the create-github-issue ability'
+);
+
+// A page_url for a DIFFERENT subsite resolves to THAT subsite's repo — proving
+// the signal is the page, not a fixed default.
+$GLOBALS['extrachill_roadie_test_state']['ability_calls'] = array();
+$shop_inferred = $tool->handle_tool_call( array(
+	'action'   => 'file_issue',
+	'title'    => 'Cart total mis-renders',
+	'body'     => 'The shop cart total shows the wrong currency symbol.',
+	'page_url' => 'https://shop.extrachill.test/cart/',
+) );
+roadie_test_assert(
+	'Extra-Chill/extrachill-shop' === ( $shop_inferred['data']['repo'] ?? '' ),
+	'a shop page_url infers the shop repo — inference tracks the page, not a default. Got: ' . ( $shop_inferred['data']['repo'] ?? '(none)' )
+);
+
+// Explicit repo still wins over page_url inference.
+$GLOBALS['extrachill_roadie_test_state']['ability_calls'] = array();
+$page_explicit = $tool->handle_tool_call( array(
+	'action'   => 'file_issue',
+	'repo'     => 'Extra-Chill/extrachill-roadie',
+	'title'    => 'Explicit beats page_url',
+	'body'     => 'Caller named the repo even though they were on the events page.',
+	'page_url' => 'https://events.extrachill.test/calendar/',
+) );
+roadie_test_assert(
+	'Extra-Chill/extrachill-roadie' === ( $page_explicit['data']['repo'] ?? '' ),
+	'explicit repo param overrides page_url inference'
+);
+roadie_test_assert(
+	false === ( $page_explicit['data']['repo_inferred'] ?? true ),
+	'explicit repo (with page_url present) is not flagged inferred'
+);
+
+// An OFF-NETWORK page_url does not resolve to a blog, so inference falls back
+// to the executing blog (blog 1). Blog 1 has no registered subsite plugin but
+// its active theme (extrachill) IS in the registry, so inference resolves to
+// the theme repo — proving the fallback path runs against the executing blog,
+// not the unresolved page_url.
+$GLOBALS['extrachill_roadie_test_state']['ability_calls'] = array();
+$offnet = $tool->handle_tool_call( array(
+	'action'   => 'file_issue',
+	'title'    => 'Off-network page',
+	'body'     => 'page_url is some external site.',
+	'page_url' => 'https://example.com/some/page/',
+) );
+roadie_test_assert(
+	'Extra-Chill/extrachill' === ( $offnet['data']['repo'] ?? '' ),
+	'off-network page_url falls back to the executing blog (blog 1 → theme repo), not the unresolved external URL. Got: ' . ( $offnet['data']['repo'] ?? '(none)' )
+);
+
+// The tool advertises the page_url client-context binding so the runtime can
+// merge client_context['page_url'] into the param automatically (same
+// mechanism inspect_page uses).
+$page_def = $tool->getToolDefinition();
+roadie_test_assert(
+	( $page_def['client_context_bindings']['page_url'] ?? '' ) === 'page_url',
+	'definition advertises the page_url client-context binding'
+);
+roadie_test_assert(
+	( $reg['meta']['client_context_bindings']['page_url'] ?? '' ) === 'page_url',
+	'registration meta advertises the page_url client-context binding for the runtime merge'
+);
+roadie_test_assert(
+	isset( $page_def['parameters']['properties']['page_url'] ),
+	'definition exposes a page_url parameter slot for the binding'
+);
+roadie_test_assert(
+	! in_array( 'page_url', $page_def['parameters']['required'] ?? array(), true ),
+	'page_url is optional (normally supplied from client context, not the model)'
+);
+
+// Tear down the per-blog/network test seams so later assertions use the flat
+// defaults.
+unset(
+	$GLOBALS['extrachill_roadie_test_state']['network_sites'],
+	$GLOBALS['extrachill_roadie_test_state']['active_plugins_by_blog']
+);
+
 // Restore the default blog/plugins for any later assertions.
 $GLOBALS['extrachill_roadie_test_state']['current_blog']   = 1;
 $GLOBALS['extrachill_roadie_test_state']['active_plugins'] = array();


### PR DESCRIPTION
## Summary

Roadie's `file_feature_request` tool inferred the target GitHub repo from `get_current_blog_id()` only — i.e. the blog the chat turn happens to *execute* on, never the page the user actually had open. On a single-repo subsite that's fine, but the **main site (blog 1)** spans several repos (theme, `extrachill-blog`, `extrachill-seo`, `extrachill-admin-tools`), so blog-id inference is inherently ambiguous there. That's exactly why qrisg — chatting on the extrachill.com homepage about the homepage design — got asked *"Which repo should this issue go to?"* instead of Roadie just knowing.

This wires the page the user was viewing (`page_url`) into repo inference as the disambiguating signal.

## What changed

- **`inc/tools/class-file-feature-request.php`**
  - Declares a `client_context_bindings` of `page_url => page_url` (registration meta **and** tool definition) — the *exact* mechanism `inspect_page` (#58) already uses. The runtime merges `client_context['page_url']` (populated by `inc/frontend-chat.php`) into the tool's `page_url` param; a caller-supplied value still wins per `WP_Agent_Tool_Parameters::buildParameters`.
  - Adds an optional `page_url` parameter to the schema (documented as "normally auto-supplied from client context").
  - Threads `page_url` through `candidate_repos_from_context()` / `infer_repo_from_context()`.
- **`inc/contribute-code/subsite-context.php`**
  - New `extrachill_roadie_blog_id_from_page_url()` — resolves a front-end URL to its owning blog via core `get_blog_id_from_url()` (host + path), with subdirectory-network path walking. Returns 0 for empty/unparseable/off-network URLs.
- **Inference flow**: `page_url → blog id` (preferred) → existing `extrachill_roadie_detect_subsite_context()` → existing slug-to-repo registry. Falls back to `get_current_blog_id()` when no `page_url` is supplied or it doesn't resolve to a network site.

## Layer purity (RULES.md)

Selection stays **registry-driven**. `page_url → blog id` is pure WordPress multisite topology (core `get_blog_id_from_url()`); `blog id → repos` is unchanged (subsite-context detector + slug-to-repo registry). **No plugin-name special-casing** anywhere in the inference path — adding a subsite to the network is sufficient, no inference-code change needed.

## Tests

Extended `tests/feature-request-tool.php` (+ `get_blog_id_from_url` / `wp_parse_url` stubs and a per-blog active-plugins seam in the bootstrap) to prove:
- A turn executing on **blog 1** with a `page_url` of `events.extrachill.test/calendar/` infers **`Extra-Chill/extrachill-events`**, not a blog-1 repo.
- A `shop.extrachill.test` `page_url` infers `Extra-Chill/extrachill-shop` — inference tracks the page, not a default.
- Explicit `repo` still overrides `page_url` inference (and isn't flagged `repo_inferred`).
- An off-network `page_url` falls back to the executing blog (blog 1 → theme repo).
- The tool advertises the `page_url` client-context binding in both registration meta and definition, with an optional `page_url` param slot.

All 14 smoke suites pass; `php -l` clean on both changed source files.

---
_Filed via Roadie page-url-repo-inference work for @chubes._