### PR TITLE
fix: instruct model not to restate present_question choices as prose (#65)

### DIFF
--- a/inc/agent-mode/register.php
+++ b/inc/agent-mode/register.php
@@ -366,7 +366,7 @@ function extrachill_roadie_guidance_posture_public(): string {
 - **Be a helpful guide, not a doer.** You are here to orient a visitor, answer questions about Extra Chill, and recommend where to go next.
 - **Don't fake actions.** If something needs a signed-in team member, say so plainly and warmly — don't pretend to do it.
 - **Keep it short and music-forward.** Visitors are exploring; give them a reason to stick around.
-- **Branching choices** — when the next step is a pick from a small, well-defined set of options, call `present_question` to render clickable choices instead of asking an open-ended question.
+- **Branching choices** — when the next step is a pick from a small, well-defined set of options, call `present_question` to render clickable choices instead of asking an open-ended question. The card **is** the question: it already shows the prompt and every choice as a clickable button. Do **not** also write the question or the choices out as prose (no bullet/numbered list of the options) in the same turn — that produces a duplicate the user sees twice. Let the card speak for itself.
 MD;
 }
 
@@ -384,6 +384,6 @@ function extrachill_roadie_guidance_posture_team(): string {
 - **Content changes** — propose then act. Show what you are about to write before you write it, especially for public-facing content (link pages, artist bios, forum posts). One short proposal is enough; do not over-explain.
 - **Cite sources** — when you pull data from a tool result, reference what you saw (artist ID, topic ID, link section). This makes corrections cheap.
 - **Errors are signals, not blockers** — tool error responses include `error_type` (validation, not_found, permission, system) and often `remediation` hints. Read them and adjust; do not retry blindly.
-- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. Reserve open-ended questions for genuinely free-form input. When the user already wants to file feedback and has given a concrete idea, prefer filing over another round of `present_question` (see *Filing Feedback*).
+- **Branching choices** — when the next step is a pick from a small, well-defined set of options (yes/no, choose one of N), call `present_question` to render clickable choices instead of asking an open-ended question. The card **is** the question: it already shows the prompt and every choice as a clickable button. Do **not** also write the question or the choices out as prose (no bullet/numbered list of the options) in the same turn — that produces a duplicate the user sees twice and answers by typing instead of clicking. Let the card speak for itself. Reserve open-ended questions for genuinely free-form input. When the user already wants to file feedback and has given a concrete idea, prefer filing over another round of `present_question` (see *Filing Feedback*).
 MD;
 }


### PR DESCRIPTION
## Summary

Prompt-side **safety net** for #65 (Roadie double-renders `present_question`: a real `QuestionCard` PLUS a duplicate prose bullet-list). The deterministic, render-side fix lives in the chat package (Extra-Chill/chat#60); this PR is the belt-and-suspenders complement, not the primary fix.

## What changed and which layer (and why)

**Prompt-side**, `inc/agent-mode/register.php` — the "Branching choices" guidance in both the public and team operating-posture blocks (the lines #65 references at ~369/387). Previously the prompt told the model to *call* `present_question` but never told it **not to also narrate the choices as prose**. A chatty model (gpt-5.4-nano) defaults to explaining what it just did, so it writes the bullet list as commentary around the tool call.

Added clause: the card **is** the question — it already shows the prompt and every choice as a clickable button, so the model must not also write the question/choices out as a prose bullet or numbered list in the same turn.

**Why this layer in addition to render-side:** prompt compliance is best-effort, so it cannot be the *only* fix — hence the deterministic render-side suppression in chat#60 is the real guarantee. But cutting the duplicate at the source (the model not emitting it) is cheap, reduces wasted tokens, and helps any surface that renders Roadie's transcript without the updated chat package. Defense in depth.

## Exact change

Both "Branching choices" bullets now end with: *"The card **is** the question … Do **not** also write the question or the choices out as prose … Let the card speak for itself."* No tool surface or behavior changes; guidance text only.

## Verification

- `php -l inc/agent-mode/register.php` → no syntax errors.
- `php tests/agent-mode-registration-smoke.php` → passed (14 assertions).

## Cross-references

- Fixes #65 (together with the render-side primary fix)
- Primary render-side fix: Extra-Chill/chat#60
- Related: #61, #63 (producer side — ensures a card EXISTS; this + chat#60 ensure it isn't shadowed by a prose dupe)